### PR TITLE
Añadir entidad weather para los ayuntamientos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,14 @@
-name: Add release file for download in HA into release
+name: Publish Home Assistant release
 
 on:
+  push:
+    branches:
+      - "publish/v*"
   release:
     types: [published]
+
+permissions:
+  contents: write
 
 jobs:
   release:
@@ -10,17 +16,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Create zip file
         run: |
           cd custom_components/meteogalicia
           zip ../../homeassistant-meteogalicia.zip -r ./
-      - name: Upload zip to release
-        uses: svenstaro/upload-release-action@v2
+
+      - name: Determine tag from publication branch
+        if: github.event_name == 'push'
+        id: version
+        run: echo "tag=${GITHUB_REF_NAME#publish/}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish release
+        if: github.event_name == 'push'
+        uses: softprops/action-gh-release@v3
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: homeassistant-meteogalicia.zip
-          asset_name: homeassistant-meteogalicia.zip
-          tag: ${{ github.ref }}
-          overwrite: true
+          tag_name: ${{ steps.version.outputs.tag }}
+          target_commitish: ${{ github.sha }}
+          generate_release_notes: true
+          files: homeassistant-meteogalicia.zip
+          fail_on_unmatched_files: true
+
+      - name: Attach zip to manually published release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: homeassistant-meteogalicia.zip
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Create zip file
         run: |
@@ -30,7 +30,7 @@ jobs:
 
       - name: Publish release
         if: github.event_name == 'push'
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           target_commitish: ${{ github.sha }}
@@ -40,7 +40,7 @@ jobs:
 
       - name: Attach zip to manually published release
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: homeassistant-meteogalicia.zip

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Esta integración para [Home Assistant](https://www.home-assistant.io/) te permi
 Proporciona sensores y una entidad meteorológica:
 
 - Para un ayuntamiento dado
-  - Entidad `weather` con el estado del cielo actual y la previsión diaria disponible (temperaturas máxima y mínima, probabilidad de lluvia e índice UV).
+  - Entidad `weather` con la temperatura observada, el estado del cielo previsto para la franja actual y la previsión diaria disponible (temperaturas máxima y mínima, probabilidad de lluvia e índice UV).
   - Observación meteorológica:
     - Temperatura actual.
   - Pronósticos:

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ Esta integración para [Home Assistant](https://www.home-assistant.io/) te permi
 
 ## Características
 
-Proporciona los siguientes sensores:
+Proporciona sensores y una entidad meteorológica:
 
 - Para un ayuntamiento dado
+  - Entidad `weather` con el estado del cielo actual y la previsión diaria disponible (temperaturas máxima y mínima, probabilidad de lluvia e índice UV).
   - Observación meteorológica:
     - Temperatura actual.
   - Pronósticos:
@@ -135,6 +136,7 @@ MeteoGalicia no requiere autenticacion ni credenciales.
 ## Entidades
 
 - Concello (forecast + observation):
+  - Entidad meteorológica (`weather`) con previsión diaria
   - Temperatura actual
   - Max/Min hoy y manana
   - Probabilidad de lluvia hoy y manana

--- a/custom_components/meteogalicia/__init__.py
+++ b/custom_components/meteogalicia/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 from .const import DOMAIN
 from .util import safe_close_coordinators
 
-PLATFORMS = ["sensor"]
+PLATFORMS = ["sensor", "weather"]
 
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:

--- a/custom_components/meteogalicia/coordinator.py
+++ b/custom_components/meteogalicia/coordinator.py
@@ -30,6 +30,51 @@ _SHARED_SESSION = requests.Session()
 _SHARED_SESSION_LOCK = asyncio.Lock()
 
 
+async def async_get_entry_coordinator(
+    hass: HomeAssistant,
+    entry_id: str,
+    coordinator_class,
+    id_value: str,
+    scan_interval,
+):
+    """Return one initialized coordinator per config entry, class and id.
+
+    Sensor and weather platforms are loaded concurrently by Home Assistant.  Keeping
+    the initialization task in the entry data makes both platforms await the same
+    first refresh instead of creating duplicate API polling loops.
+    """
+    entry_data = (
+        hass.data.setdefault(const.DOMAIN, {})
+        .setdefault(entry_id, {})
+    )
+    tasks = entry_data.setdefault("coordinator_tasks", {})
+    key = (coordinator_class.__name__, id_value)
+    task = tasks.get(key)
+
+    if task is None:
+        async def _async_create_and_refresh():
+            coordinator = coordinator_class(hass, id_value, scan_interval)
+            coordinators = entry_data.setdefault("coordinators", [])
+            coordinators.append(coordinator)
+            try:
+                await coordinator.async_refresh()
+            except Exception:
+                coordinators.remove(coordinator)
+                raise
+            return coordinator
+
+        task = hass.async_create_task(_async_create_and_refresh())
+        tasks[key] = task
+
+    try:
+        return await task
+    except Exception:
+        # Allow Home Assistant to retry platform setup after an unexpected failure.
+        if tasks.get(key) is task:
+            tasks.pop(key, None)
+        raise
+
+
 def _get_scan_interval(config_scan_interval: timedelta | int | float | None) -> timedelta:
     if isinstance(config_scan_interval, (int, float)):
         return timedelta(seconds=config_scan_interval)

--- a/custom_components/meteogalicia/manifest.json
+++ b/custom_components/meteogalicia/manifest.json
@@ -11,8 +11,10 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Danieldiazi/homeassistant-meteogalicia/issues",
   "quality_scale": "silver",
-  "requirements": ["MeteoGalicia-API==0.1.2"],
+  "requirements": [
+    "MeteoGalicia-API==0.1.2"
+  ],
   "ssdp": [],
-  "version": "2026.02.3",
+  "version": "2026.08.0",
   "zeroconf": []
 }

--- a/custom_components/meteogalicia/sensor.py
+++ b/custom_components/meteogalicia/sensor.py
@@ -28,6 +28,7 @@ from .coordinator import (
     MeteoGaliciaObservationCoordinator,
     MeteoGaliciaStationDailyCoordinator,
     MeteoGaliciaStationLast10MinCoordinator,
+    async_get_entry_coordinator,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -169,7 +170,12 @@ async def async_setup_entry(hass, entry, add_entities):
     if data.get(const.CONF_ID_CONCELLO, ""):
         id_concello = data[const.CONF_ID_CONCELLO]
         await setup_id_concello_platform(
-            id_concello, add_entities, hass, scan_interval, coordinators
+            id_concello,
+            add_entities,
+            hass,
+            scan_interval,
+            coordinators,
+            entry.entry_id,
         )
     elif data.get(const.CONF_ID_ESTACION, ""):
         id_estacion = data[const.CONF_ID_ESTACION]
@@ -259,7 +265,12 @@ async def setup_id_estacion_platform(
 
 
 async def setup_id_concello_platform(
-    id_concello, add_entities, hass, scan_interval, coordinators=None
+    id_concello,
+    add_entities,
+    hass,
+    scan_interval,
+    coordinators=None,
+    entry_id=None,
 ):
         """Configura la plataforma de concello y añade los sensores correspondientes."""
         # id_concello must to have 5 chars and be a number
@@ -269,12 +280,21 @@ async def setup_id_concello_platform(
             )
             return False
         else:
-            forecast_coordinator = MeteoGaliciaForecastCoordinator(
-                hass, id_concello, scan_interval
-            )
-            if coordinators is not None:
-                coordinators.append(forecast_coordinator)
-            await forecast_coordinator.async_refresh()
+            if entry_id is not None:
+                forecast_coordinator = await async_get_entry_coordinator(
+                    hass,
+                    entry_id,
+                    MeteoGaliciaForecastCoordinator,
+                    id_concello,
+                    scan_interval,
+                )
+            else:
+                forecast_coordinator = MeteoGaliciaForecastCoordinator(
+                    hass, id_concello, scan_interval
+                )
+                if coordinators is not None:
+                    coordinators.append(forecast_coordinator)
+                await forecast_coordinator.async_refresh()
             if (
                 not forecast_coordinator.last_update_success
                 or not forecast_coordinator.data
@@ -286,12 +306,21 @@ async def setup_id_concello_platform(
             if not name:
                 raise PlatformNotReady
 
-            observation_coordinator = MeteoGaliciaObservationCoordinator(
-                hass, id_concello, scan_interval
-            )
-            if coordinators is not None:
-                coordinators.append(observation_coordinator)
-            await observation_coordinator.async_refresh()
+            if entry_id is not None:
+                observation_coordinator = await async_get_entry_coordinator(
+                    hass,
+                    entry_id,
+                    MeteoGaliciaObservationCoordinator,
+                    id_concello,
+                    scan_interval,
+                )
+            else:
+                observation_coordinator = MeteoGaliciaObservationCoordinator(
+                    hass, id_concello, scan_interval
+                )
+                if coordinators is not None:
+                    coordinators.append(observation_coordinator)
+                await observation_coordinator.async_refresh()
             
             forecast_temperature_by_day_sensor_config= [
                 ("Today", 0, "tMax"),

--- a/custom_components/meteogalicia/weather.py
+++ b/custom_components/meteogalicia/weather.py
@@ -3,19 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.weather import (
-    ATTR_CONDITION_CLOUDY,
-    ATTR_CONDITION_FOG,
-    ATTR_CONDITION_HAIL,
-    ATTR_CONDITION_LIGHTNING_RAINY,
-    ATTR_CONDITION_PARTLYCLOUDY,
-    ATTR_CONDITION_RAINY,
-    ATTR_CONDITION_SNOWY,
-    ATTR_CONDITION_SNOWY_RAINY,
-    ATTR_CONDITION_SUNNY,
-    WeatherEntity,
-    WeatherEntityFeature,
-)
+from homeassistant.components.weather import WeatherEntity, WeatherEntityFeature
 from homeassistant.const import CONF_SCAN_INTERVAL, UnitOfTemperature
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity import DeviceInfo
@@ -29,31 +17,31 @@ ATTRIBUTION = "Data provided by MeteoGalicia"
 
 # MeteoGalicia uses the same final two digits for equivalent day/night icons.
 _CONDITION_BY_CODE = {
-    1: ATTR_CONDITION_SUNNY,
-    2: ATTR_CONDITION_PARTLYCLOUDY,
-    3: ATTR_CONDITION_PARTLYCLOUDY,
-    4: ATTR_CONDITION_CLOUDY,
-    5: ATTR_CONDITION_CLOUDY,
-    6: ATTR_CONDITION_FOG,
-    7: ATTR_CONDITION_RAINY,
-    8: ATTR_CONDITION_RAINY,
-    9: ATTR_CONDITION_SNOWY_RAINY,
-    10: ATTR_CONDITION_RAINY,
-    11: ATTR_CONDITION_RAINY,
-    12: ATTR_CONDITION_SNOWY,
-    13: ATTR_CONDITION_LIGHTNING_RAINY,
-    14: ATTR_CONDITION_FOG,
-    15: ATTR_CONDITION_FOG,
-    16: ATTR_CONDITION_PARTLYCLOUDY,
-    17: ATTR_CONDITION_RAINY,
-    18: ATTR_CONDITION_RAINY,
-    19: ATTR_CONDITION_LIGHTNING_RAINY,
-    20: ATTR_CONDITION_SNOWY_RAINY,
-    21: ATTR_CONDITION_HAIL,
-    22: ATTR_CONDITION_RAINY,
-    23: ATTR_CONDITION_SNOWY,
-    24: ATTR_CONDITION_FOG,
-    25: ATTR_CONDITION_CLOUDY,
+    1: "sunny",
+    2: "partlycloudy",
+    3: "partlycloudy",
+    4: "cloudy",
+    5: "cloudy",
+    6: "fog",
+    7: "rainy",
+    8: "rainy",
+    9: "snowy-rainy",
+    10: "rainy",
+    11: "rainy",
+    12: "snowy",
+    13: "lightning-rainy",
+    14: "fog",
+    15: "fog",
+    16: "partlycloudy",
+    17: "rainy",
+    18: "rainy",
+    19: "lightning-rainy",
+    20: "snowy-rainy",
+    21: "hail",
+    22: "rainy",
+    23: "snowy",
+    24: "fog",
+    25: "cloudy",
 }
 
 

--- a/custom_components/meteogalicia/weather.py
+++ b/custom_components/meteogalicia/weather.py
@@ -14,6 +14,7 @@ from . import const
 from .coordinator import (
     MeteoGaliciaForecastCoordinator,
     MeteoGaliciaObservationCoordinator,
+    async_get_entry_coordinator,
 )
 
 ATTRIBUTION = "Data provided by MeteoGalicia"
@@ -109,6 +110,11 @@ def _forecast_days(data: dict[str, Any] | None) -> list[dict[str, Any]]:
     return days if isinstance(days, list) else []
 
 
+def _weather_unique_id(id_concello: str) -> str:
+    """Return the stable unique id for a municipal weather entity."""
+    return f"meteogalicia_weather_{id_concello}"
+
+
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     """Set up a MeteoGalicia weather entity from a config entry."""
     data = _merge_entry_data(entry)
@@ -116,26 +122,21 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     if not id_concello:
         return
 
-    coordinator = MeteoGaliciaForecastCoordinator(
+    coordinator = await async_get_entry_coordinator(
         hass,
+        entry.entry_id,
+        MeteoGaliciaForecastCoordinator,
         id_concello,
         entry.options.get(CONF_SCAN_INTERVAL),
     )
-    coordinators = (
-        hass.data.setdefault(const.DOMAIN, {})
-        .setdefault(entry.entry_id, {})
-        .setdefault("coordinators", [])
-    )
-    coordinators.append(coordinator)
-    await coordinator.async_config_entry_first_refresh()
 
-    observation_coordinator = MeteoGaliciaObservationCoordinator(
+    observation_coordinator = await async_get_entry_coordinator(
         hass,
+        entry.entry_id,
+        MeteoGaliciaObservationCoordinator,
         id_concello,
         entry.options.get(CONF_SCAN_INTERVAL),
     )
-    coordinators.append(observation_coordinator)
-    await observation_coordinator.async_refresh()
 
     pred_concello = (coordinator.data or {}).get("predConcello")
     if not isinstance(pred_concello, dict) or not pred_concello.get("nome"):
@@ -173,7 +174,7 @@ class MeteoGaliciaWeather(CoordinatorEntity, WeatherEntity):
         self._observation_coordinator = observation_coordinator
         self._municipality_name = name
         self._id_concello = id_concello
-        self._attr_unique_id = f"meteogalicia_weather_{id_concello}"
+        self._attr_unique_id = _weather_unique_id(id_concello)
         self._attr_device_info = DeviceInfo(
             identifiers={(const.DOMAIN, f"concello_{id_concello}")},
             name=f"{const.INTEGRATION_NAME} {name}",

--- a/custom_components/meteogalicia/weather.py
+++ b/custom_components/meteogalicia/weather.py
@@ -11,7 +11,10 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from . import const
-from .coordinator import MeteoGaliciaForecastCoordinator
+from .coordinator import (
+    MeteoGaliciaForecastCoordinator,
+    MeteoGaliciaObservationCoordinator,
+)
 
 ATTRIBUTION = "Data provided by MeteoGalicia"
 
@@ -126,6 +129,14 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     coordinators.append(coordinator)
     await coordinator.async_config_entry_first_refresh()
 
+    observation_coordinator = MeteoGaliciaObservationCoordinator(
+        hass,
+        id_concello,
+        entry.options.get(CONF_SCAN_INTERVAL),
+    )
+    coordinators.append(observation_coordinator)
+    await observation_coordinator.async_refresh()
+
     pred_concello = (coordinator.data or {}).get("predConcello")
     if not isinstance(pred_concello, dict) or not pred_concello.get("nome"):
         raise PlatformNotReady
@@ -136,6 +147,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
                 pred_concello["nome"],
                 id_concello,
                 coordinator,
+                observation_coordinator,
             )
         ]
     )
@@ -150,8 +162,15 @@ class MeteoGaliciaWeather(CoordinatorEntity, WeatherEntity):
     _attr_native_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_supported_features = WeatherEntityFeature.FORECAST_DAILY
 
-    def __init__(self, name: str, id_concello: str, coordinator) -> None:
+    def __init__(
+        self,
+        name: str,
+        id_concello: str,
+        coordinator,
+        observation_coordinator,
+    ) -> None:
         super().__init__(coordinator)
+        self._observation_coordinator = observation_coordinator
         self._municipality_name = name
         self._id_concello = id_concello
         self._attr_unique_id = f"meteogalicia_weather_{id_concello}"
@@ -160,6 +179,32 @@ class MeteoGaliciaWeather(CoordinatorEntity, WeatherEntity):
             name=f"{const.INTEGRATION_NAME} {name}",
             manufacturer=const.INTEGRATION_NAME,
         )
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to measured-observation updates."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._observation_coordinator.async_add_listener(
+                self.async_write_ha_state
+            )
+        )
+
+    @property
+    def native_temperature(self) -> float | None:
+        """Return the latest temperature actually observed for the municipality."""
+        data = self._observation_coordinator.data
+        if not isinstance(data, dict):
+            return None
+        observations = data.get("listaObservacionConcellos")
+        if not isinstance(observations, list) or not observations:
+            return None
+        temperature = observations[0].get("temperatura")
+        if temperature in (None, -9999):
+            return None
+        try:
+            return float(temperature)
+        except (TypeError, ValueError):
+            return None
 
     @property
     def condition(self) -> str | None:
@@ -183,7 +228,7 @@ class MeteoGaliciaWeather(CoordinatorEntity, WeatherEntity):
                     "native_temperature": _valid_value(item.get("tMax")),
                     "native_templow": _valid_value(item.get("tMin")),
                     "precipitation_probability": _maximum_probability(item),
-                    "native_uv_index": _valid_value(item.get("uvMax")),
+                    "uv_index": _valid_value(item.get("uvMax")),
                 }
             )
         return forecast or None

--- a/custom_components/meteogalicia/weather.py
+++ b/custom_components/meteogalicia/weather.py
@@ -1,0 +1,201 @@
+"""Weather entity for the MeteoGalicia integration."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.weather import (
+    ATTR_CONDITION_CLOUDY,
+    ATTR_CONDITION_FOG,
+    ATTR_CONDITION_HAIL,
+    ATTR_CONDITION_LIGHTNING_RAINY,
+    ATTR_CONDITION_PARTLYCLOUDY,
+    ATTR_CONDITION_RAINY,
+    ATTR_CONDITION_SNOWY,
+    ATTR_CONDITION_SNOWY_RAINY,
+    ATTR_CONDITION_SUNNY,
+    WeatherEntity,
+    WeatherEntityFeature,
+)
+from homeassistant.const import CONF_SCAN_INTERVAL, UnitOfTemperature
+from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
+
+from . import const
+from .coordinator import MeteoGaliciaForecastCoordinator
+
+ATTRIBUTION = "Data provided by MeteoGalicia"
+
+# MeteoGalicia uses the same final two digits for equivalent day/night icons.
+_CONDITION_BY_CODE = {
+    1: ATTR_CONDITION_SUNNY,
+    2: ATTR_CONDITION_PARTLYCLOUDY,
+    3: ATTR_CONDITION_PARTLYCLOUDY,
+    4: ATTR_CONDITION_CLOUDY,
+    5: ATTR_CONDITION_CLOUDY,
+    6: ATTR_CONDITION_FOG,
+    7: ATTR_CONDITION_RAINY,
+    8: ATTR_CONDITION_RAINY,
+    9: ATTR_CONDITION_SNOWY_RAINY,
+    10: ATTR_CONDITION_RAINY,
+    11: ATTR_CONDITION_RAINY,
+    12: ATTR_CONDITION_SNOWY,
+    13: ATTR_CONDITION_LIGHTNING_RAINY,
+    14: ATTR_CONDITION_FOG,
+    15: ATTR_CONDITION_FOG,
+    16: ATTR_CONDITION_PARTLYCLOUDY,
+    17: ATTR_CONDITION_RAINY,
+    18: ATTR_CONDITION_RAINY,
+    19: ATTR_CONDITION_LIGHTNING_RAINY,
+    20: ATTR_CONDITION_SNOWY_RAINY,
+    21: ATTR_CONDITION_HAIL,
+    22: ATTR_CONDITION_RAINY,
+    23: ATTR_CONDITION_SNOWY,
+    24: ATTR_CONDITION_FOG,
+    25: ATTR_CONDITION_CLOUDY,
+}
+
+
+def _merge_entry_data(entry) -> dict[str, Any]:
+    """Merge config entry data and options, allowing options to clear values."""
+    data = dict(entry.data)
+    for key, value in entry.options.items():
+        if value in ("", None):
+            data.pop(key, None)
+        else:
+            data[key] = value
+    return data
+
+
+def _condition_from_code(value: Any) -> str | None:
+    """Translate a MeteoGalicia sky code to a Home Assistant condition."""
+    try:
+        code = int(value)
+    except (TypeError, ValueError):
+        return None
+    if code == -9999:
+        return None
+    return _CONDITION_BY_CODE.get(code % 100)
+
+
+def _time_period() -> str:
+    """Return the MeteoGalicia period for the current local time."""
+    hour = dt_util.now().hour
+    if 6 <= hour < 14:
+        return "manha"
+    if 14 <= hour < 21:
+        return "tarde"
+    return "noite"
+
+
+def _valid_value(value: Any) -> Any:
+    """Return None for MeteoGalicia's unavailable sentinel."""
+    return None if value == -9999 else value
+
+
+def _maximum_probability(item: dict[str, Any]) -> int | None:
+    """Return the maximum valid rain probability for a forecast day."""
+    probabilities = item.get("pchoiva")
+    if not isinstance(probabilities, dict):
+        return None
+    values = [
+        value
+        for value in probabilities.values()
+        if isinstance(value, (int, float)) and value >= 0
+    ]
+    return int(max(values)) if values else None
+
+
+def _forecast_days(data: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Extract valid daily forecast records."""
+    if not isinstance(data, dict):
+        return []
+    pred_concello = data.get("predConcello")
+    if not isinstance(pred_concello, dict):
+        return []
+    days = pred_concello.get("listaPredDiaConcello")
+    return days if isinstance(days, list) else []
+
+
+async def async_setup_entry(hass, entry, async_add_entities) -> None:
+    """Set up a MeteoGalicia weather entity from a config entry."""
+    data = _merge_entry_data(entry)
+    id_concello = data.get(const.CONF_ID_CONCELLO)
+    if not id_concello:
+        return
+
+    coordinator = MeteoGaliciaForecastCoordinator(
+        hass,
+        id_concello,
+        entry.options.get(CONF_SCAN_INTERVAL),
+    )
+    coordinators = (
+        hass.data.setdefault(const.DOMAIN, {})
+        .setdefault(entry.entry_id, {})
+        .setdefault("coordinators", [])
+    )
+    coordinators.append(coordinator)
+    await coordinator.async_config_entry_first_refresh()
+
+    pred_concello = (coordinator.data or {}).get("predConcello")
+    if not isinstance(pred_concello, dict) or not pred_concello.get("nome"):
+        raise PlatformNotReady
+
+    async_add_entities(
+        [
+            MeteoGaliciaWeather(
+                pred_concello["nome"],
+                id_concello,
+                coordinator,
+            )
+        ]
+    )
+
+
+class MeteoGaliciaWeather(CoordinatorEntity, WeatherEntity):
+    """Municipal MeteoGalicia forecast."""
+
+    _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_native_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_supported_features = WeatherEntityFeature.FORECAST_DAILY
+
+    def __init__(self, name: str, id_concello: str, coordinator) -> None:
+        super().__init__(coordinator)
+        self._municipality_name = name
+        self._id_concello = id_concello
+        self._attr_unique_id = f"meteogalicia_weather_{id_concello}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(const.DOMAIN, f"concello_{id_concello}")},
+            name=f"{const.INTEGRATION_NAME} {name}",
+            manufacturer=const.INTEGRATION_NAME,
+        )
+
+    @property
+    def condition(self) -> str | None:
+        """Return the condition for the current part of today."""
+        days = _forecast_days(self.coordinator.data)
+        if not days:
+            return None
+        sky = days[0].get("ceo")
+        if isinstance(sky, dict):
+            return _condition_from_code(sky.get(_time_period()))
+        return _condition_from_code(days[0].get("ceoDia"))
+
+    async def async_forecast_daily(self) -> list[dict[str, Any]] | None:
+        """Return the daily forecast."""
+        forecast = []
+        for item in _forecast_days(self.coordinator.data):
+            forecast.append(
+                {
+                    "datetime": item.get("dataPredicion"),
+                    "condition": _condition_from_code(item.get("ceoDia")),
+                    "native_temperature": _valid_value(item.get("tMax")),
+                    "native_templow": _valid_value(item.get("tMin")),
+                    "precipitation_probability": _maximum_probability(item),
+                    "native_uv_index": _valid_value(item.get("uvMax")),
+                }
+            )
+        return forecast or None

--- a/tests/test_coordinator_cache.py
+++ b/tests/test_coordinator_cache.py
@@ -35,9 +35,9 @@ class CountingCoordinator:
 
 
 @pytest.mark.asyncio
-async def test_entry_platforms_share_one_coordinator_and_refresh():
-    CountingCoordinator.created = 0
-    CountingCoordinator.refreshed = 0
+async def test_entry_platforms_share_one_coordinator_and_refresh(monkeypatch):
+    monkeypatch.setattr(CountingCoordinator, "created", 0)
+    monkeypatch.setattr(CountingCoordinator, "refreshed", 0)
     hass = DummyHass()
 
     first, second = await asyncio.gather(
@@ -57,9 +57,9 @@ async def test_entry_platforms_share_one_coordinator_and_refresh():
 
 
 @pytest.mark.asyncio
-async def test_different_entries_do_not_share_coordinators():
-    CountingCoordinator.created = 0
-    CountingCoordinator.refreshed = 0
+async def test_different_entries_do_not_share_coordinators(monkeypatch):
+    monkeypatch.setattr(CountingCoordinator, "created", 0)
+    monkeypatch.setattr(CountingCoordinator, "refreshed", 0)
     hass = DummyHass()
 
     first = await async_get_entry_coordinator(
@@ -75,7 +75,7 @@ async def test_different_entries_do_not_share_coordinators():
 
 
 @pytest.mark.asyncio
-async def test_failed_initialization_can_be_retried():
+async def test_failed_initialization_can_be_retried(monkeypatch):
     class FailingCoordinator(CountingCoordinator):
         failures = 1
 
@@ -85,8 +85,9 @@ async def test_failed_initialization_can_be_retried():
                 raise TimeoutError
             await super().async_refresh()
 
-    FailingCoordinator.created = 0
-    FailingCoordinator.refreshed = 0
+    monkeypatch.setattr(FailingCoordinator, "created", 0)
+    monkeypatch.setattr(FailingCoordinator, "refreshed", 0)
+    monkeypatch.setattr(FailingCoordinator, "failures", 1)
     hass = DummyHass()
 
     with pytest.raises(TimeoutError):

--- a/tests/test_coordinator_cache.py
+++ b/tests/test_coordinator_cache.py
@@ -1,0 +1,103 @@
+"""Tests for shared config-entry coordinators."""
+import asyncio
+
+import pytest
+
+from custom_components.meteogalicia import const
+from custom_components.meteogalicia.coordinator import async_get_entry_coordinator
+
+
+class DummyHass:
+    """Minimal Home Assistant stand-in used by the coordinator cache."""
+
+    def __init__(self):
+        self.data = {}
+
+    @staticmethod
+    def async_create_task(coro):
+        return asyncio.create_task(coro)
+
+
+class CountingCoordinator:
+    """Coordinator that records construction and first refreshes."""
+
+    created = 0
+    refreshed = 0
+
+    def __init__(self, hass, id_value, scan_interval):
+        type(self).created += 1
+        self.id = id_value
+        self.scan_interval = scan_interval
+
+    async def async_refresh(self):
+        type(self).refreshed += 1
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_entry_platforms_share_one_coordinator_and_refresh():
+    CountingCoordinator.created = 0
+    CountingCoordinator.refreshed = 0
+    hass = DummyHass()
+
+    first, second = await asyncio.gather(
+        async_get_entry_coordinator(
+            hass, "entry", CountingCoordinator, "15030", 1200
+        ),
+        async_get_entry_coordinator(
+            hass, "entry", CountingCoordinator, "15030", 1200
+        ),
+    )
+
+    assert first is second
+    assert first.scan_interval == 1200
+    assert CountingCoordinator.created == 1
+    assert CountingCoordinator.refreshed == 1
+    assert hass.data[const.DOMAIN]["entry"]["coordinators"] == [first]
+
+
+@pytest.mark.asyncio
+async def test_different_entries_do_not_share_coordinators():
+    CountingCoordinator.created = 0
+    CountingCoordinator.refreshed = 0
+    hass = DummyHass()
+
+    first = await async_get_entry_coordinator(
+        hass, "entry-1", CountingCoordinator, "15030", 1200
+    )
+    second = await async_get_entry_coordinator(
+        hass, "entry-2", CountingCoordinator, "15030", 1200
+    )
+
+    assert first is not second
+    assert CountingCoordinator.created == 2
+    assert CountingCoordinator.refreshed == 2
+
+
+@pytest.mark.asyncio
+async def test_failed_initialization_can_be_retried():
+    class FailingCoordinator(CountingCoordinator):
+        failures = 1
+
+        async def async_refresh(self):
+            if type(self).failures:
+                type(self).failures -= 1
+                raise TimeoutError
+            await super().async_refresh()
+
+    FailingCoordinator.created = 0
+    FailingCoordinator.refreshed = 0
+    hass = DummyHass()
+
+    with pytest.raises(TimeoutError):
+        await async_get_entry_coordinator(
+            hass, "entry", FailingCoordinator, "15030", 1200
+        )
+
+    coordinator = await async_get_entry_coordinator(
+        hass, "entry", FailingCoordinator, "15030", 1200
+    )
+
+    assert coordinator.id == "15030"
+    assert FailingCoordinator.created == 2
+    assert hass.data[const.DOMAIN]["entry"]["coordinators"] == [coordinator]

--- a/tests/test_coordinator_cache.py
+++ b/tests/test_coordinator_cache.py
@@ -18,87 +18,80 @@ class DummyHass:
         return asyncio.create_task(coro)
 
 
-class CountingCoordinator:
-    """Coordinator that records construction and first refreshes."""
+def counting_coordinator(stats):
+    """Create an isolated coordinator double backed by per-test counters."""
 
-    created = 0
-    refreshed = 0
+    class CountingCoordinator:
+        def __init__(self, hass, id_value, scan_interval):
+            stats["created"] += 1
+            self.id = id_value
+            self.scan_interval = scan_interval
 
-    def __init__(self, hass, id_value, scan_interval):
-        type(self).created += 1
-        self.id = id_value
-        self.scan_interval = scan_interval
+        async def async_refresh(self):
+            stats["refreshed"] += 1
+            if stats["failures"]:
+                stats["failures"] -= 1
+                raise TimeoutError
+            await asyncio.sleep(0)
 
-    async def async_refresh(self):
-        type(self).refreshed += 1
-        await asyncio.sleep(0)
+    return CountingCoordinator
 
 
 @pytest.mark.asyncio
-async def test_entry_platforms_share_one_coordinator_and_refresh(monkeypatch):
-    monkeypatch.setattr(CountingCoordinator, "created", 0)
-    monkeypatch.setattr(CountingCoordinator, "refreshed", 0)
+async def test_entry_platforms_share_one_coordinator_and_refresh():
+    stats = {"created": 0, "refreshed": 0, "failures": 0}
+    coordinator_class = counting_coordinator(stats)
     hass = DummyHass()
 
     first, second = await asyncio.gather(
         async_get_entry_coordinator(
-            hass, "entry", CountingCoordinator, "15030", 1200
+            hass, "entry", coordinator_class, "15030", 1200
         ),
         async_get_entry_coordinator(
-            hass, "entry", CountingCoordinator, "15030", 1200
+            hass, "entry", coordinator_class, "15030", 1200
         ),
     )
 
     assert first is second
     assert first.scan_interval == 1200
-    assert CountingCoordinator.created == 1
-    assert CountingCoordinator.refreshed == 1
+    assert stats["created"] == 1
+    assert stats["refreshed"] == 1
     assert hass.data[const.DOMAIN]["entry"]["coordinators"] == [first]
 
 
 @pytest.mark.asyncio
-async def test_different_entries_do_not_share_coordinators(monkeypatch):
-    monkeypatch.setattr(CountingCoordinator, "created", 0)
-    monkeypatch.setattr(CountingCoordinator, "refreshed", 0)
+async def test_different_entries_do_not_share_coordinators():
+    stats = {"created": 0, "refreshed": 0, "failures": 0}
+    coordinator_class = counting_coordinator(stats)
     hass = DummyHass()
 
     first = await async_get_entry_coordinator(
-        hass, "entry-1", CountingCoordinator, "15030", 1200
+        hass, "entry-1", coordinator_class, "15030", 1200
     )
     second = await async_get_entry_coordinator(
-        hass, "entry-2", CountingCoordinator, "15030", 1200
+        hass, "entry-2", coordinator_class, "15030", 1200
     )
 
     assert first is not second
-    assert CountingCoordinator.created == 2
-    assert CountingCoordinator.refreshed == 2
+    assert stats["created"] == 2
+    assert stats["refreshed"] == 2
 
 
 @pytest.mark.asyncio
-async def test_failed_initialization_can_be_retried(monkeypatch):
-    class FailingCoordinator(CountingCoordinator):
-        failures = 1
-
-        async def async_refresh(self):
-            if type(self).failures:
-                type(self).failures -= 1
-                raise TimeoutError
-            await super().async_refresh()
-
-    monkeypatch.setattr(FailingCoordinator, "created", 0)
-    monkeypatch.setattr(FailingCoordinator, "refreshed", 0)
-    monkeypatch.setattr(FailingCoordinator, "failures", 1)
+async def test_failed_initialization_can_be_retried():
+    stats = {"created": 0, "refreshed": 0, "failures": 1}
+    coordinator_class = counting_coordinator(stats)
     hass = DummyHass()
 
     with pytest.raises(TimeoutError):
         await async_get_entry_coordinator(
-            hass, "entry", FailingCoordinator, "15030", 1200
+            hass, "entry", coordinator_class, "15030", 1200
         )
 
     coordinator = await async_get_entry_coordinator(
-        hass, "entry", FailingCoordinator, "15030", 1200
+        hass, "entry", coordinator_class, "15030", 1200
     )
 
     assert coordinator.id == "15030"
-    assert FailingCoordinator.created == 2
+    assert stats["created"] == 2
     assert hass.data[const.DOMAIN]["entry"]["coordinators"] == [coordinator]

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,121 @@
+"""Tests for the MeteoGalicia weather entity helpers."""
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.meteogalicia import weather
+from custom_components.meteogalicia.weather import (
+    MeteoGaliciaWeather,
+    _condition_from_code,
+    _forecast_days,
+    _maximum_probability,
+    _valid_value,
+    _weather_unique_id,
+)
+
+
+def test_condition_codes_are_mapped_and_unavailable_is_ignored():
+    assert _condition_from_code(101) == "sunny"
+    assert _condition_from_code(111) == "rainy"
+    assert _condition_from_code(113) == "lightning-rainy"
+    assert _condition_from_code(-9999) is None
+    assert _condition_from_code("invalid") is None
+
+
+def test_forecast_helpers_handle_valid_and_missing_data():
+    day = {
+        "pchoiva": {"manha": 10, "tarde": 60, "noite": -9999},
+    }
+    payload = {"predConcello": {"listaPredDiaConcello": [day]}}
+
+    assert _forecast_days(payload) == [day]
+    assert _forecast_days({}) == []
+    assert _maximum_probability(day) == 60
+    assert _maximum_probability({"pchoiva": {"manha": -9999}}) is None
+    assert _valid_value(-9999) is None
+    assert _valid_value(18) == 18
+
+
+def _weather_without_init(observation_data=None, forecast_data=None):
+    entity = object.__new__(MeteoGaliciaWeather)
+    entity._observation_coordinator = SimpleNamespace(data=observation_data)
+    entity.coordinator = SimpleNamespace(data=forecast_data)
+    return entity
+
+
+def test_native_temperature_uses_observed_value():
+    entity = _weather_without_init(
+        {"listaObservacionConcellos": [{"temperatura": "18.4"}]}
+    )
+
+    assert entity.native_temperature == pytest.approx(18.4)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        {},
+        {"listaObservacionConcellos": []},
+        {"listaObservacionConcellos": [{"temperatura": -9999}]},
+        {"listaObservacionConcellos": [{"temperatura": "invalid"}]},
+    ],
+)
+def test_native_temperature_handles_unavailable_observations(payload):
+    assert _weather_without_init(payload).native_temperature is None
+
+
+def test_current_condition_uses_forecast_time_period(monkeypatch):
+    entity = _weather_without_init(
+        forecast_data={
+            "predConcello": {
+                "listaPredDiaConcello": [
+                    {"ceo": {"manha": 101, "tarde": 111, "noite": 203}}
+                ]
+            }
+        }
+    )
+    monkeypatch.setattr(weather, "_time_period", lambda: "tarde")
+
+    assert entity.condition == "rainy"
+
+
+@pytest.mark.asyncio
+async def test_daily_forecast_uses_forecast_payload():
+    entity = _weather_without_init(
+        forecast_data={
+            "predConcello": {
+                "listaPredDiaConcello": [
+                    {
+                        "dataPredicion": "2026-08-08",
+                        "ceoDia": 103,
+                        "tMax": 24,
+                        "tMin": 15,
+                        "pchoiva": {"manha": 10, "tarde": 30, "noite": 20},
+                        "uvMax": 7,
+                    }
+                ]
+            }
+        }
+    )
+
+    assert await entity.async_forecast_daily() == [
+        {
+            "datetime": "2026-08-08",
+            "condition": "partlycloudy",
+            "native_temperature": 24,
+            "native_templow": 15,
+            "precipitation_probability": 30,
+            "uv_index": 7,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_daily_forecast_handles_empty_response():
+    assert await _weather_without_init(forecast_data={}).async_forecast_daily() is None
+
+
+def test_weather_unique_id_is_new_and_stable():
+    assert _weather_unique_id("15009") == "meteogalicia_weather_15009"
+    assert _weather_unique_id("15009") != "meteogalicia_betanzos_temperature_15009"


### PR DESCRIPTION
## Resumen

- añade una entidad `weather` para cada entrada de tipo ayuntamiento
- usa `observation` para la temperatura actual realmente observada
- usa `forecast` para el estado del cielo y la previsión diaria
- comparte los coordinadores entre `sensor` y `weather`, evitando duplicar consultas y conservando el `scan_interval`
- expone máximas, mínimas, probabilidad de lluvia e índice UV
- conserva sin cambios los identificadores de todos los sensores existentes
- añade pruebas para coordinadores compartidos, timeouts, datos vacíos, valores no disponibles, previsiones y el nuevo `unique_id`
- actualiza la documentación y la versión a `2026.08.0`

## Comportamiento

La temperatura actual procede de los datos observados por MeteoGalicia. La condición se obtiene de la predicción municipal para la franja horaria local (mañana, tarde o noche), y la previsión incluye todos los días disponibles en la respuesta del servicio.

Las plataformas `sensor` y `weather` esperan la misma inicialización de cada coordinador, por lo que solo existe un ciclo de consulta de `forecast` y otro de `observation` por entrada.

Closes #19