### PR TITLE
Importar automáticamente la configuración YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,67 +63,26 @@ Una vez cumplidos los objetivos anteriores, los pasos a seguir para la instalaci
    - Completa el formulario y guarda.
    - (Opcional) En la pantalla de opciones puedes ajustar `scan_interval` en segundos.
 
-5. Configurarla mediante el fichero de configuración `configuration.yaml` (u otro que uses):
+5. Reinicia Home Assistant y espera unos minutos a que aparezcan las nuevas entidades.
 
- Si quieres añadir la información para un ayuntamiento dado:
-``` yaml
-sensor:
-  platform: meteogalicia
-  id_concello: 32054
-  scan_interval: 1200
+### Migración automática desde YAML
 
-```
+Las configuraciones antiguas con `platform: meteogalicia` se importan automáticamente como entradas de configuración al actualizar la integración y reiniciar Home Assistant.
 
-Puedes poner más de un sensor, por ejemplo:
+- Se crea una entrada por cada bloque YAML.
+- Se conservan `id_concello`, `id_estacion`, la medida seleccionada y el `scan_interval` exacto.
+- Se mantienen los `unique_id` de las entidades para conservar sus identificadores e historial.
+- Si la entrada ya existe, no se crea un duplicado.
+- En **Ajustes → Sistema → Reparaciones** aparece un aviso con el bloque correspondiente que ya puedes eliminar de `configuration.yaml`.
+- El aviso desaparece después de retirar el bloque YAML y reiniciar Home Assistant.
 
-``` yaml
-sensor:
-  - platform: meteogalicia
-    id_concello: 32054
-    scan_interval: 1200
-  - platform: meteogalicia
-    id_concello: 15023
-    scan_interval: 1800
-```
-
-
-- La lista de id's para escoger el parámetro "id_concello" se pueden encontrar en el enlace [info.md](info.md)
-- Con el parámetro opcional "scan_interval" indicas cada cuanto tiempo se conecta a meteogalicia para obtener la información. El valor es en segundos, por tanto, si pones 1200  hará el chequeo cada 20 minutos. Es recomendable usarlo.
-
-En el caso de que quieras añadir información de estaciones meteorológicas:
-``` yaml
-sensor:
-  platform: meteogalicia
-  id_estacion: 10124
-  scan_interval: 1800
-```
-Este ejemplo creará dos sensores,  uno para los últimos datos diarios y otro para los 10-minutales. En los atributos de cada sensor aparecerán todos los valores de las medidas que proporciona esa estación, si quieres que uno de esos valores sea el valor del estado del sensor creado, deberás usar el parámetro "id_estacion_medida_diarios" si la fuente de datos es de datos diarios o "id_estacion_medida_ultimos_10_min" si la fuente de datos diarios es la de los ultimos 10-minutales. Por ejemplo:
-
-``` yaml
-sensor:
-  - platform: meteogalicia
-    id_estacion: 10124
-    id_estacion_medida_diarios: BH_SUM_1.5m
-    scan_interval: 1800
-  - platform: meteogalicia
-    id_estacion: 10124
-    id_estacion_medida_ultimos_10_min: DV_AVG_10m
-    scan_interval: 1800
-```
-
-- La lista de id's se pueden encontrar en el enlace [info.md](info.md)
-- Con el parámetro opcional "scan_interval" indicas cada cuanto tiempo se conecta a meteogalicia para obtener la información. El valor es en segundos, por tanto, si pones 1200  hará el chequeo cada 20 minutos. Es recomendable usarlo.
-  
-6. Reiniciar para que recarge la configuración y espera unos minutos a que aparezcan las nuevas entidades, con id: sensor.meteogalicia_XXXX.
+No añadas nuevas configuraciones YAML: utiliza **Ajustes → Dispositivos y servicios → Añadir integración → MeteoGalicia**.
 
 ### Update interval (scan_interval)
 
-- El `scan_interval` se aplica por cada config entry (UI) o por cada bloque en YAML, no por sensor individual.
+- El `scan_interval` se aplica por cada entrada de configuración, no por sensor individual.
 - Todas las entidades que cuelgan del mismo coordinador comparten el mismo `update_interval`.
-- Puedes tener varias entradas del mismo tipo (por UI y/o YAML) y cada una puede usar un intervalo distinto.
-
-
-Nota: si usas YAML, la integracion no aparece en la lista de integraciones de Home Assistant.
+- Puedes tener varias entradas del mismo tipo y cada una puede usar un intervalo distinto.
 
 ## Diagnostics
 

--- a/custom_components/meteogalicia/config_flow.py
+++ b/custom_components/meteogalicia/config_flow.py
@@ -126,10 +126,12 @@ class MeteoGaliciaConfigFlow(config_entries.ConfigFlow, domain=const.DOMAIN):
         if unique_id is None:
             return self.async_abort(reason="invalid_import")
 
-        if id_concello := data.get(const.CONF_ID_CONCELLO):
-            if len(id_concello) != 5 or not id_concello.isnumeric():
-                return self.async_abort(reason="invalid_import")
-        else:
+        id_concello = data.get(const.CONF_ID_CONCELLO)
+        if id_concello and (
+            len(id_concello) != 5 or not id_concello.isnumeric()
+        ):
+            return self.async_abort(reason="invalid_import")
+        if not id_concello:
             id_estacion = data[const.CONF_ID_ESTACION]
             errors = {}
             if len(id_estacion) != 5 or not id_estacion.isnumeric():

--- a/custom_components/meteogalicia/config_flow.py
+++ b/custom_components/meteogalicia/config_flow.py
@@ -13,12 +13,30 @@ from . import const
 def _clean_data(data: dict) -> dict:
     return {key: value for key, value in data.items() if value not in ("", None)}
 
+
+def _unique_id_from_data(data: dict) -> str | None:
+    """Return the config-entry unique ID represented by configuration data."""
+    if id_concello := data.get(const.CONF_ID_CONCELLO):
+        return f"concello_{id_concello}"
+
+    if not (id_estacion := data.get(const.CONF_ID_ESTACION)):
+        return None
+
+    id_daily = data.get(const.CONF_ID_ESTACION_MEDIDA_DAILY, "")
+    id_last10 = data.get(const.CONF_ID_ESTACION_MEDIDA_LAST10MIN, "")
+    unique_id = f"estacion_{id_estacion}"
+    if id_daily or id_last10:
+        unique_id = f"{unique_id}_{id_daily}_{id_last10}"
+    return unique_id
+
+
 def _validate_station_measures(user_input: dict, errors: dict) -> None:
     id_daily = user_input.get(const.CONF_ID_ESTACION_MEDIDA_DAILY, "")
     id_last10 = user_input.get(const.CONF_ID_ESTACION_MEDIDA_LAST10MIN, "")
     if id_daily and id_last10:
         errors[const.CONF_ID_ESTACION_MEDIDA_DAILY] = "only_one_measure"
         errors[const.CONF_ID_ESTACION_MEDIDA_LAST10MIN] = "only_one_measure"
+
 
 def _merge_entry_data(entry: config_entries.ConfigEntry) -> dict:
     """Merge entry data and options, allowing options to clear values."""
@@ -99,6 +117,33 @@ class MeteoGaliciaConfigFlow(config_entries.ConfigFlow, domain=const.DOMAIN):
             step_id="station",
             data_schema=schema,
             errors=errors,
+        )
+
+    async def async_step_import(self, import_data):
+        """Import one legacy sensor platform block from YAML."""
+        data = _clean_data(dict(import_data))
+        unique_id = _unique_id_from_data(data)
+        if unique_id is None:
+            return self.async_abort(reason="invalid_import")
+
+        if id_concello := data.get(const.CONF_ID_CONCELLO):
+            if len(id_concello) != 5 or not id_concello.isnumeric():
+                return self.async_abort(reason="invalid_import")
+        else:
+            id_estacion = data[const.CONF_ID_ESTACION]
+            errors = {}
+            if len(id_estacion) != 5 or not id_estacion.isnumeric():
+                return self.async_abort(reason="invalid_import")
+            _validate_station_measures(data, errors)
+            if errors:
+                return self.async_abort(reason="invalid_import")
+
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured()
+        identifier = id_concello or data[const.CONF_ID_ESTACION]
+        return self.async_create_entry(
+            title=f"MeteoGalicia {identifier}",
+            data=data,
         )
 
     @staticmethod

--- a/custom_components/meteogalicia/manifest.json
+++ b/custom_components/meteogalicia/manifest.json
@@ -15,6 +15,6 @@
     "MeteoGalicia-API==0.1.2"
   ],
   "ssdp": [],
-  "version": "2026.08.0",
+  "version": "2026.08.1",
   "zeroconf": []
 }

--- a/custom_components/meteogalicia/sensor.py
+++ b/custom_components/meteogalicia/sensor.py
@@ -1,15 +1,19 @@
 # -*- coding: utf-8 -*-
 """Módulo de sensores para la integración MeteoGalicia."""
 import logging
+import re
+
 import voluptuous as vol
+
+from homeassistant import config_entries
 from homeassistant.const import (
     CONF_SCAN_INTERVAL,
-    EVENT_HOMEASSISTANT_STOP,
     PERCENTAGE,
     STATE_UNKNOWN,
     UnitOfTemperature,
 )
 from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt
@@ -22,7 +26,6 @@ from homeassistant.components.sensor import (
 )
 
 from . import const
-from .util import safe_close_coordinators
 from .coordinator import (
     MeteoGaliciaForecastCoordinator,
     MeteoGaliciaObservationCoordinator,
@@ -33,6 +36,7 @@ from .coordinator import (
 
 _LOGGER = logging.getLogger(__name__)
 ATTRIBUTION = "Data provided by MeteoGalicia"
+
 
 def _base_attrs(entity_id: str) -> dict:
     """Crea atributos base comunes."""
@@ -107,6 +111,62 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     
 )
 
+_YAML_IMPORT_KEYS = (
+    const.CONF_ID_CONCELLO,
+    const.CONF_ID_ESTACION,
+    const.CONF_ID_ESTACION_MEDIDA_DAILY,
+    const.CONF_ID_ESTACION_MEDIDA_LAST10MIN,
+    CONF_SCAN_INTERVAL,
+)
+
+
+def _yaml_import_data(config: dict) -> dict:
+    """Return serializable config-entry data from a legacy YAML block."""
+    data = {
+        key: config[key]
+        for key in _YAML_IMPORT_KEYS
+        if config.get(key) is not None
+    }
+    scan_interval = data.get(CONF_SCAN_INTERVAL)
+    if hasattr(scan_interval, "total_seconds"):
+        data[CONF_SCAN_INTERVAL] = int(scan_interval.total_seconds())
+    return data
+
+
+def _yaml_configuration(data: dict) -> str:
+    """Render the imported YAML block for the Repairs notification."""
+    lines = ["sensor:", "  - platform: meteogalicia"]
+    for key in _YAML_IMPORT_KEYS:
+        if key in data:
+            lines.append(f"    {key}: {data[key]}")
+    return "\n".join(lines)
+
+
+def _yaml_issue_id(data: dict) -> str:
+    """Return one stable Repairs issue ID per imported YAML block."""
+    parts = [str(data.get(key, "")) for key in _YAML_IMPORT_KEYS[:-1]]
+    suffix = re.sub(r"[^a-zA-Z0-9_-]+", "_", "_".join(parts)).strip("_")
+    return f"yaml_imported_{suffix}"
+
+
+def _create_yaml_import_issue(hass, data: dict) -> None:
+    """Tell the user which successfully imported YAML block can be removed."""
+    identifier = data.get(const.CONF_ID_CONCELLO) or data.get(const.CONF_ID_ESTACION)
+    ir.async_create_issue(
+        hass,
+        const.DOMAIN,
+        _yaml_issue_id(data),
+        is_fixable=False,
+        is_persistent=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="yaml_imported",
+        translation_placeholders={
+            "configuration": _yaml_configuration(data),
+            "identifier": str(identifier),
+        },
+    )
+
+
 def _merge_entry_data(entry):
     """Mezcla datos y opciones de la entrada, permitiendo vaciar valores."""
     data = dict(entry.data)
@@ -126,41 +186,21 @@ def _validate_id(value: str, expected_len: int, label: str) -> bool:
 async def async_setup_platform(
     hass, config, add_entities, discovery_info=None
 ):  # pylint: disable=missing-docstring, unused-argument
-    """Configura la plataforma de sensores definida en YAML."""
-    scan_interval = config.get(CONF_SCAN_INTERVAL)
-    coordinators = (
-        hass.data.setdefault(const.DOMAIN, {}).setdefault("yaml_coordinators", [])
+    """Import a legacy YAML sensor block into a config entry."""
+    data = _yaml_import_data(config)
+    result = await hass.config_entries.flow.async_init(
+        const.DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data=data,
     )
-    if not hass.data[const.DOMAIN].get("yaml_close_registered"):
-        hass.data[const.DOMAIN]["yaml_close_registered"] = True
-
-        async def _close_yaml_coordinators(event):
-            coordinators = hass.data.get(const.DOMAIN, {}).get(
-                "yaml_coordinators", []
-            )
-            await safe_close_coordinators(coordinators)
-
-        hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, _close_yaml_coordinators
-        )
-
-    if config.get(const.CONF_ID_CONCELLO, ""):
-        id_concello = config[const.CONF_ID_CONCELLO]
-        await setup_id_concello_platform(
-            id_concello, add_entities, hass, scan_interval, coordinators
-        )
-
-    elif config.get(const.CONF_ID_ESTACION, ""):
-        id_estacion = config[const.CONF_ID_ESTACION]
-        await setup_id_estacion_platform(
-            id_estacion, config, add_entities, hass, scan_interval, coordinators
-        )
+    if result.get("reason") != "invalid_import":
+        _create_yaml_import_issue(hass, data)
 
 
 async def async_setup_entry(hass, entry, add_entities):
     """Configura sensores de MeteoGalicia desde una entrada de configuración."""
-    scan_interval = entry.options.get(CONF_SCAN_INTERVAL)
     data = _merge_entry_data(entry)
+    scan_interval = data.get(CONF_SCAN_INTERVAL)
     coordinators = (
         hass.data.setdefault(const.DOMAIN, {})
         .setdefault(entry.entry_id, {})

--- a/custom_components/meteogalicia/sensor.py
+++ b/custom_components/meteogalicia/sensor.py
@@ -184,7 +184,7 @@ def _validate_id(value: str, expected_len: int, label: str) -> bool:
 
 
 async def async_setup_platform(
-    hass, config, add_entities, discovery_info=None
+    hass, config, add_entities, _discovery_info=None
 ):  # pylint: disable=missing-docstring, unused-argument
     """Import a legacy YAML sensor block into a config entry."""
     data = _yaml_import_data(config)

--- a/custom_components/meteogalicia/sensor.py
+++ b/custom_components/meteogalicia/sensor.py
@@ -184,7 +184,7 @@ def _validate_id(value: str, expected_len: int, label: str) -> bool:
 
 
 async def async_setup_platform(
-    hass, config, add_entities, _discovery_info=None
+    hass, config, _add_entities, _discovery_info=None
 ):  # pylint: disable=missing-docstring, unused-argument
     """Import a legacy YAML sensor block into a config entry."""
     data = _yaml_import_data(config)

--- a/custom_components/meteogalicia/translations/en.json
+++ b/custom_components/meteogalicia/translations/en.json
@@ -27,6 +27,15 @@
     "error": {
       "invalid_id": "The ID must be exactly 5 digits.",
       "only_one_measure": "Only one measure can be used: daily or last 10 min."
+    },
+    "abort": {
+      "invalid_import": "The MeteoGalicia YAML configuration is invalid."
+    }
+  },
+  "issues": {
+    "yaml_imported": {
+      "title": "Remove the imported MeteoGalicia YAML configuration",
+      "description": "The MeteoGalicia YAML configuration for `{identifier}` was successfully imported as a config entry. Remove this block from `configuration.yaml` and restart Home Assistant:\n\n```yaml\n{configuration}\n```\n\nThe imported entry keeps the entity identifiers and update interval. This notification will disappear after the block is removed and Home Assistant is restarted."
     }
   },
   "options": {

--- a/custom_components/meteogalicia/translations/es.json
+++ b/custom_components/meteogalicia/translations/es.json
@@ -27,6 +27,15 @@
     "error": {
       "invalid_id": "El ID debe tener exactamente 5 digitos.",
       "only_one_measure": "Solo puedes usar una medida: diaria o ultimos 10 min."
+    },
+    "abort": {
+      "invalid_import": "La configuración YAML de MeteoGalicia no es válida."
+    }
+  },
+  "issues": {
+    "yaml_imported": {
+      "title": "Retira la configuración YAML importada de MeteoGalicia",
+      "description": "La configuración YAML de MeteoGalicia para `{identifier}` se ha importado correctamente como una entrada de configuración. Elimina este bloque de `configuration.yaml` y reinicia Home Assistant:\n\n```yaml\n{configuration}\n```\n\nLa entrada importada conserva los identificadores de las entidades y el intervalo de actualización. Este aviso desaparecerá después de retirar el bloque y reiniciar."
     }
   },
   "options": {

--- a/custom_components/meteogalicia/translations/gl.json
+++ b/custom_components/meteogalicia/translations/gl.json
@@ -27,6 +27,15 @@
     "error": {
       "only_one_measure": "So podes usar unha medida: diaria ou ultimos 10 min.",
       "invalid_id": "O ID debe ter exactamente 5 díxitos."
+    },
+    "abort": {
+      "invalid_import": "A configuración YAML de MeteoGalicia non é válida."
+    }
+  },
+  "issues": {
+    "yaml_imported": {
+      "title": "Retira a configuración YAML importada de MeteoGalicia",
+      "description": "A configuración YAML de MeteoGalicia para `{identifier}` importouse correctamente como unha entrada de configuración. Elimina este bloque de `configuration.yaml` e reinicia Home Assistant:\n\n```yaml\n{configuration}\n```\n\nA entrada importada conserva os identificadores das entidades e o intervalo de actualización. Este aviso desaparecerá despois de retirar o bloque e reiniciar."
     }
   },
   "options": {

--- a/custom_components/meteogalicia/weather.py
+++ b/custom_components/meteogalicia/weather.py
@@ -118,6 +118,7 @@ def _weather_unique_id(id_concello: str) -> str:
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     """Set up a MeteoGalicia weather entity from a config entry."""
     data = _merge_entry_data(entry)
+    scan_interval = data.get(CONF_SCAN_INTERVAL)
     id_concello = data.get(const.CONF_ID_CONCELLO)
     if not id_concello:
         return
@@ -127,7 +128,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
         entry.entry_id,
         MeteoGaliciaForecastCoordinator,
         id_concello,
-        entry.options.get(CONF_SCAN_INTERVAL),
+        scan_interval,
     )
 
     observation_coordinator = await async_get_entry_coordinator(
@@ -135,7 +136,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
         entry.entry_id,
         MeteoGaliciaObservationCoordinator,
         id_concello,
-        entry.options.get(CONF_SCAN_INTERVAL),
+        scan_interval,
     )
 
     pred_concello = (coordinator.data or {}).get("predConcello")

--- a/tests/test_yaml_import.py
+++ b/tests/test_yaml_import.py
@@ -1,0 +1,125 @@
+"""Tests for importing legacy MeteoGalicia YAML configuration."""
+from datetime import timedelta
+
+import pytest
+
+from custom_components.meteogalicia import const, sensor
+from custom_components.meteogalicia.config_flow import _unique_id_from_data
+from custom_components.meteogalicia.sensor import (
+    _yaml_configuration,
+    _yaml_import_data,
+    _yaml_issue_id,
+)
+
+
+def test_yaml_forecast_import_preserves_interval():
+    data = _yaml_import_data(
+        {
+            const.CONF_ID_CONCELLO: "15009",
+            "scan_interval": timedelta(seconds=1700),
+        }
+    )
+
+    assert data == {
+        const.CONF_ID_CONCELLO: "15009",
+        "scan_interval": 1700,
+    }
+    assert _unique_id_from_data(data) == "concello_15009"
+    assert _yaml_configuration(data) == (
+        "sensor:\n"
+        "  - platform: meteogalicia\n"
+        "    id_concello: 15009\n"
+        "    scan_interval: 1700"
+    )
+
+
+def test_yaml_station_import_preserves_measure_and_has_stable_issue_id():
+    data = _yaml_import_data(
+        {
+            const.CONF_ID_ESTACION: "10124",
+            const.CONF_ID_ESTACION_MEDIDA_DAILY: "BH_SUM_1.5m",
+            "scan_interval": timedelta(seconds=1800),
+        }
+    )
+
+    assert _unique_id_from_data(data) == "estacion_10124_BH_SUM_1.5m_"
+    assert _yaml_issue_id(data) == "yaml_imported_10124_BH_SUM_1_5m"
+    assert "id_estacion_medida_diarios: BH_SUM_1.5m" in _yaml_configuration(data)
+
+
+def test_different_station_measures_create_different_imports():
+    daily = {
+        const.CONF_ID_ESTACION: "10124",
+        const.CONF_ID_ESTACION_MEDIDA_DAILY: "BH_SUM_1.5m",
+    }
+    last10 = {
+        const.CONF_ID_ESTACION: "10124",
+        const.CONF_ID_ESTACION_MEDIDA_LAST10MIN: "DV_AVG_10m",
+    }
+
+    assert _unique_id_from_data(daily) != _unique_id_from_data(last10)
+    assert _yaml_issue_id(daily) != _yaml_issue_id(last10)
+
+
+@pytest.mark.asyncio
+async def test_yaml_platform_imports_entry_and_creates_repair(monkeypatch):
+    flow_calls = []
+    issue_calls = []
+
+    class FlowManager:
+        async def async_init(self, domain, *, context, data):
+            flow_calls.append((domain, context, data))
+            return {"type": "create_entry"}
+
+    class ConfigEntries:
+        flow = FlowManager()
+
+    class Hass:
+        config_entries = ConfigEntries()
+
+    monkeypatch.setattr(
+        sensor.ir,
+        "async_create_issue",
+        lambda *args, **kwargs: issue_calls.append((args, kwargs)),
+    )
+
+    await sensor.async_setup_platform(
+        Hass(),
+        {
+            const.CONF_ID_CONCELLO: "15009",
+            "scan_interval": timedelta(seconds=1700),
+        },
+        lambda entities: pytest.fail(f"Unexpected YAML entities: {entities}"),
+    )
+
+    assert flow_calls == [
+        (
+            const.DOMAIN,
+            {"source": sensor.config_entries.SOURCE_IMPORT},
+            {const.CONF_ID_CONCELLO: "15009", "scan_interval": 1700},
+        )
+    ]
+    assert len(issue_calls) == 1
+    assert issue_calls[0][1]["translation_key"] == "yaml_imported"
+    assert issue_calls[0][1]["is_persistent"] is False
+
+
+@pytest.mark.asyncio
+async def test_invalid_yaml_import_does_not_claim_success(monkeypatch):
+    class FlowManager:
+        async def async_init(self, domain, *, context, data):
+            return {"type": "abort", "reason": "invalid_import"}
+
+    class ConfigEntries:
+        flow = FlowManager()
+
+    class Hass:
+        config_entries = ConfigEntries()
+
+    monkeypatch.setattr(
+        sensor.ir,
+        "async_create_issue",
+        lambda *args, **kwargs: pytest.fail("Unexpected Repairs issue"),
+    )
+
+    await sensor.async_setup_platform(Hass(), {}, lambda entities: None)


### PR DESCRIPTION
## Resumen

- importa cada bloque heredado `platform: meteogalicia` mediante el flujo estándar `SOURCE_IMPORT`
- crea una entrada de configuración por bloque sin duplicar entradas existentes
- conserva ayuntamiento o estación, medida seleccionada y `scan_interval` exacto
- mantiene los `unique_id` de las entidades para reutilizar sus identificadores e historial
- deja de crear las entidades directamente desde YAML
- añade un aviso no persistente en Reparaciones con el bloque que puede retirarse
- elimina automáticamente el aviso tras retirar el YAML y reiniciar
- actualiza la documentación, traducciones en español, gallego e inglés y la versión a `2026.08.1`

## Comportamiento de la migración

En el primer arranque, Home Assistant crea o reutiliza la entrada de configuración. Solo entonces muestra el aviso de Reparaciones. Si el bloque continúa en YAML, el aviso se vuelve a generar en cada arranque; cuando se elimina y se reinicia, desaparece.

Las opciones de la entrada prevalecen sobre los datos importados, y tanto sensores como la entidad `weather` aplican el intervalo fusionado.

## Validación

- compilación sintáctica con `py_compile`
- validación JSON de manifiesto y traducciones
- `git diff --check`
- pruebas unitarias añadidas para ayuntamientos, estaciones, medidas, intervalos, incidencias y configuraciones inválidas

No se pudo ejecutar `pytest` localmente porque el entorno no incluye `pytest` ni Home Assistant.