### PR TITLE
Mejorar recargas, fiabilidad, validación y pruebas

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   validate:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
-        - uses: "actions/checkout@v3"
-        - uses: "home-assistant/actions/hassfest@master"
+        - uses: "actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803" # v6
+        - uses: "home-assistant/actions/hassfest@a7c616ce81ccda50150bf1595786c71b1883fabb"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,10 @@ jobs:
   hacs:
     name: HACS Action
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - name: HACS Action
-        uses: "hacs/action@main"
+        uses: "hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa"
         with:
           category: "integration"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,13 @@ jobs:
           cache-dependency-path: requirements_test.txt
 
       - name: Install test dependencies
-        run: python -m pip install --requirement requirements_test.txt
+        run: >-
+          python -m pip install
+          homeassistant==2026.8.1
+          MeteoGalicia-API==0.1.2
+          pytest==9.1.1
+          pytest-asyncio==1.4.0
+          ruff==0.16.2
 
       - name: Validate Python syntax
         run: python -m compileall -q custom_components tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14.2"
+          cache: pip
+          cache-dependency-path: requirements_test.txt
+
+      - name: Install test dependencies
+        run: python -m pip install --requirement requirements_test.txt
+
+      - name: Validate Python syntax
+        run: python -m compileall -q custom_components tests
+
+      - name: Validate JSON
+        run: >-
+          python -c "import json, pathlib;
+          [json.loads(path.read_text()) for path in pathlib.Path('.').rglob('*.json')]"
+
+      - name: Run critical Ruff checks
+        run: ruff check --select E9,F63,F7,F82 custom_components tests
+
+      - name: Run unit tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -60,8 +60,11 @@ Una vez cumplidos los objetivos anteriores, los pasos a seguir para la instalaci
    - Busca "MeteoGalicia" y elige el tipo de datos:
      - Forecast (concello): usa `id_concello`.
      - Station (estacion): usa `id_estacion` y opcionalmente las medidas.
-   - Completa el formulario y guarda.
-   - (Opcional) En la pantalla de opciones puedes ajustar `scan_interval` en segundos.
+   - Completa el formulario y guarda. La integración comprueba el identificador con
+     MeteoGalicia antes de crear la entrada y utiliza el nombre real del concello o
+     de la estación.
+   - (Opcional) En la pantalla de opciones puedes ajustar `scan_interval` en segundos;
+     el nuevo intervalo se aplica automáticamente al guardar, sin reiniciar Home Assistant.
 
 5. Reinicia Home Assistant y espera unos minutos a que aparezcan las nuevas entidades.
 
@@ -83,6 +86,8 @@ No añadas nuevas configuraciones YAML: utiliza **Ajustes → Dispositivos y ser
 - El `scan_interval` se aplica por cada entrada de configuración, no por sensor individual.
 - Todas las entidades que cuelgan del mismo coordinador comparten el mismo `update_interval`.
 - Puedes tener varias entradas del mismo tipo y cada una puede usar un intervalo distinto.
+- Si MeteoGalicia devuelve temporalmente una respuesta vacía, se conservan los últimos
+  datos válidos y la actualización se marca como fallida hasta que el servicio se recupere.
 
 ## Diagnostics
 

--- a/custom_components/meteogalicia/__init__.py
+++ b/custom_components/meteogalicia/__init__.py
@@ -1,4 +1,5 @@
 """The MeteoGalicia integration."""
+
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
@@ -19,8 +20,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up MeteoGalicia from a config entry."""
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {"coordinators": []}
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload a config entry after its options change."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/meteogalicia/config_flow.py
+++ b/custom_components/meteogalicia/config_flow.py
@@ -103,20 +103,18 @@ def _validate_station(
     daily_measure = user_input.get(const.CONF_ID_ESTACION_MEDIDA_DAILY)
     last10_measure = user_input.get(const.CONF_ID_ESTACION_MEDIDA_LAST10MIN)
     selected_measure = daily_measure or last10_measure
-    if not selected_measure:
-        return f"MeteoGalicia {name}"
-
-    daily = bool(daily_measure)
-    endpoint = daily_endpoint if daily else last10_endpoint
-    payload = _request_json(session, endpoint.format(id_estacion))
-    try:
-        _station_name, measures = _station_name_and_measures(payload, daily=daily)
-    except InvalidIdentifier:
-        # Daily data can be temporarily empty around midnight. The station is
-        # already validated by the catalog, so do not reject it.
-        measures = set()
-    if measures and selected_measure not in measures:
-        raise InvalidMeasure
+    if selected_measure:
+        daily = bool(daily_measure)
+        endpoint = daily_endpoint if daily else last10_endpoint
+        payload = _request_json(session, endpoint.format(id_estacion))
+        try:
+            _station_name, measures = _station_name_and_measures(payload, daily=daily)
+        except InvalidIdentifier:
+            # Daily data can be temporarily empty around midnight. The station is
+            # already validated by the catalog, so do not reject it.
+            measures = set()
+        if measures and selected_measure not in measures:
+            raise InvalidMeasure
     return f"MeteoGalicia {name}"
 
 

--- a/custom_components/meteogalicia/config_flow.py
+++ b/custom_components/meteogalicia/config_flow.py
@@ -78,6 +78,48 @@ def _station_from_catalog(data: dict, id_estacion: str) -> dict:
     raise InvalidIdentifier
 
 
+def _validate_forecast(
+    session: requests.Session, endpoint: str, id_concello: str
+) -> str:
+    """Validate one municipal forecast identifier."""
+    payload = _request_json(session, endpoint.format(id_concello))
+    pred_concello = payload.get("predConcello") if isinstance(payload, dict) else None
+    if not isinstance(pred_concello, dict) or not pred_concello.get("nome"):
+        raise InvalidIdentifier
+    return f"MeteoGalicia {pred_concello['nome']}"
+
+
+def _validate_station(
+    session: requests.Session,
+    user_input: dict,
+    daily_endpoint: str,
+    last10_endpoint: str,
+) -> str:
+    """Validate one station identifier and its optional selected measure."""
+    id_estacion = user_input[const.CONF_ID_ESTACION]
+    catalog = _request_json(session, const.STATIONS_URL)
+    station = _station_from_catalog(catalog, id_estacion)
+    name = station.get("estacion") or id_estacion
+    daily_measure = user_input.get(const.CONF_ID_ESTACION_MEDIDA_DAILY)
+    last10_measure = user_input.get(const.CONF_ID_ESTACION_MEDIDA_LAST10MIN)
+    selected_measure = daily_measure or last10_measure
+    if not selected_measure:
+        return f"MeteoGalicia {name}"
+
+    daily = bool(daily_measure)
+    endpoint = daily_endpoint if daily else last10_endpoint
+    payload = _request_json(session, endpoint.format(id_estacion))
+    try:
+        _station_name, measures = _station_name_and_measures(payload, daily=daily)
+    except InvalidIdentifier:
+        # Daily data can be temporarily empty around midnight. The station is
+        # already validated by the catalog, so do not reject it.
+        measures = set()
+    if measures and selected_measure not in measures:
+        raise InvalidMeasure
+    return f"MeteoGalicia {name}"
+
+
 def _validate_api_input(user_input: dict) -> str:
     """Validate config data synchronously and return a descriptive entry title."""
     from meteogalicia_api.const import (
@@ -88,40 +130,13 @@ def _validate_api_input(user_input: dict) -> str:
 
     with requests.Session() as session:
         if id_concello := user_input.get(const.CONF_ID_CONCELLO):
-            payload = _request_json(session, URL_FORECAST.format(id_concello))
-            pred_concello = (
-                payload.get("predConcello") if isinstance(payload, dict) else None
-            )
-            if not isinstance(pred_concello, dict) or not pred_concello.get("nome"):
-                raise InvalidIdentifier
-            return f"MeteoGalicia {pred_concello['nome']}"
-
-        id_estacion = user_input[const.CONF_ID_ESTACION]
-        catalog = _request_json(session, const.STATIONS_URL)
-        station = _station_from_catalog(catalog, id_estacion)
-        name = station.get("estacion") or id_estacion
-        daily_measure = user_input.get(const.CONF_ID_ESTACION_MEDIDA_DAILY)
-        last10_measure = user_input.get(const.CONF_ID_ESTACION_MEDIDA_LAST10MIN)
-        selected_measure = daily_measure or last10_measure
-        if selected_measure:
-            daily = bool(daily_measure)
-            endpoint = (
-                URL_OBSERVATION_DAILYDATA_BY_STATION
-                if daily
-                else URL_OBSERVATION_LAST10MINDATA_BY_STATION
-            )
-            payload = _request_json(session, endpoint.format(id_estacion))
-            try:
-                _station_name, measures = _station_name_and_measures(
-                    payload, daily=daily
-                )
-            except InvalidIdentifier:
-                # Daily data can be temporarily empty around midnight. The station
-                # is already validated by the catalog, so do not reject it.
-                measures = set()
-            if measures and selected_measure not in measures:
-                raise InvalidMeasure
-        return f"MeteoGalicia {name}"
+            return _validate_forecast(session, URL_FORECAST, id_concello)
+        return _validate_station(
+            session,
+            user_input,
+            URL_OBSERVATION_DAILYDATA_BY_STATION,
+            URL_OBSERVATION_LAST10MINDATA_BY_STATION,
+        )
 
 
 async def _async_validate_api_input(hass, user_input: dict) -> str:

--- a/custom_components/meteogalicia/config_flow.py
+++ b/custom_components/meteogalicia/config_flow.py
@@ -1,13 +1,152 @@
 """Config flow for MeteoGalicia integration."""
+
 from __future__ import annotations
 
 import voluptuous as vol
+import requests
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_SCAN_INTERVAL
 import homeassistant.helpers.config_validation as cv
 
 from . import const
+
+
+class CannotConnect(Exception):
+    """Raised when MeteoGalicia cannot be reached."""
+
+
+class InvalidIdentifier(Exception):
+    """Raised when MeteoGalicia does not recognize an identifier."""
+
+
+class InvalidMeasure(Exception):
+    """Raised when a station does not expose the selected measure."""
+
+
+class RequestTimeout(Exception):
+    """Raised when MeteoGalicia does not answer in time."""
+
+
+def _first_item(data: dict, key: str) -> dict | None:
+    """Return the first mapping in a payload list."""
+    if not isinstance(data, dict):
+        return None
+    items = data.get(key)
+    if not isinstance(items, list) or not items or not isinstance(items[0], dict):
+        return None
+    return items[0]
+
+
+def _station_name_and_measures(data: dict, *, daily: bool) -> tuple[str, set[str]]:
+    """Extract the station name and available measure codes from an API payload."""
+    if daily:
+        day = _first_item(data, "listDatosDiarios")
+        station = _first_item(day or {}, "listaEstacions")
+    else:
+        station = _first_item(data, "listUltimos10min")
+    if station is None:
+        raise InvalidIdentifier
+
+    name = station.get("estacion")
+    if not name:
+        raise InvalidIdentifier
+    measures = station.get("listaMedidas")
+    codes = {
+        str(item["codigoParametro"])
+        for item in measures or []
+        if isinstance(item, dict) and item.get("codigoParametro")
+    }
+    return str(name), codes
+
+
+def _request_json(session: requests.Session, url: str) -> dict:
+    """Fetch and decode one MeteoGalicia JSON endpoint."""
+    response = session.get(url, timeout=const.CONFIG_FLOW_TIMEOUT)
+    response.raise_for_status()
+    return response.json()
+
+
+def _station_from_catalog(data: dict, id_estacion: str) -> dict:
+    """Return a station from MeteoGalicia's authoritative station catalog."""
+    stations = data.get("listaEstacionsMeteo") if isinstance(data, dict) else None
+    if not isinstance(stations, list):
+        raise CannotConnect
+    for station in stations:
+        if isinstance(station, dict) and str(station.get("idEstacion")) == id_estacion:
+            return station
+    raise InvalidIdentifier
+
+
+def _validate_api_input(user_input: dict) -> str:
+    """Validate config data synchronously and return a descriptive entry title."""
+    from meteogalicia_api.const import (
+        URL_FORECAST,
+        URL_OBSERVATION_DAILYDATA_BY_STATION,
+        URL_OBSERVATION_LAST10MINDATA_BY_STATION,
+    )
+
+    with requests.Session() as session:
+        if id_concello := user_input.get(const.CONF_ID_CONCELLO):
+            payload = _request_json(session, URL_FORECAST.format(id_concello))
+            pred_concello = (
+                payload.get("predConcello") if isinstance(payload, dict) else None
+            )
+            if not isinstance(pred_concello, dict) or not pred_concello.get("nome"):
+                raise InvalidIdentifier
+            return f"MeteoGalicia {pred_concello['nome']}"
+
+        id_estacion = user_input[const.CONF_ID_ESTACION]
+        catalog = _request_json(session, const.STATIONS_URL)
+        station = _station_from_catalog(catalog, id_estacion)
+        name = station.get("estacion") or id_estacion
+        daily_measure = user_input.get(const.CONF_ID_ESTACION_MEDIDA_DAILY)
+        last10_measure = user_input.get(const.CONF_ID_ESTACION_MEDIDA_LAST10MIN)
+        selected_measure = daily_measure or last10_measure
+        if selected_measure:
+            daily = bool(daily_measure)
+            endpoint = (
+                URL_OBSERVATION_DAILYDATA_BY_STATION
+                if daily
+                else URL_OBSERVATION_LAST10MINDATA_BY_STATION
+            )
+            payload = _request_json(session, endpoint.format(id_estacion))
+            try:
+                _station_name, measures = _station_name_and_measures(
+                    payload, daily=daily
+                )
+            except InvalidIdentifier:
+                # Daily data can be temporarily empty around midnight. The station
+                # is already validated by the catalog, so do not reject it.
+                measures = set()
+            if measures and selected_measure not in measures:
+                raise InvalidMeasure
+        return f"MeteoGalicia {name}"
+
+
+async def _async_validate_api_input(hass, user_input: dict) -> str:
+    """Validate config data without blocking Home Assistant's event loop."""
+    try:
+        return await hass.async_add_executor_job(_validate_api_input, user_input)
+    except requests.Timeout as err:
+        raise RequestTimeout from err
+    except requests.RequestException as err:
+        raise CannotConnect from err
+
+
+async def _validated_title(hass, user_input: dict, errors: dict) -> str | None:
+    """Run API validation and map failures to config-flow error keys."""
+    try:
+        return await _async_validate_api_input(hass, user_input)
+    except InvalidIdentifier:
+        errors["base"] = "unknown_id"
+    except InvalidMeasure:
+        errors["base"] = "invalid_measure"
+    except RequestTimeout:
+        errors["base"] = "timeout"
+    except CannotConnect:
+        errors["base"] = "cannot_connect"
+    return None
 
 
 def _clean_data(data: dict) -> dict:
@@ -74,10 +213,12 @@ class MeteoGaliciaConfigFlow(config_entries.ConfigFlow, domain=const.DOMAIN):
                 unique_id = f"concello_{id_concello}"
                 await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_configured()
-                return self.async_create_entry(
-                    title="MeteoGalicia",
-                    data=_clean_data(user_input),
-                )
+                title = await _validated_title(self.hass, user_input, errors)
+                if title:
+                    return self.async_create_entry(
+                        title=title,
+                        data=_clean_data(user_input),
+                    )
 
         schema = vol.Schema({vol.Required(const.CONF_ID_CONCELLO): str})
         return self.async_show_form(
@@ -101,10 +242,12 @@ class MeteoGaliciaConfigFlow(config_entries.ConfigFlow, domain=const.DOMAIN):
                     unique_id = f"{unique_id}_{id_daily}_{id_last10}"
                 await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_configured()
-                return self.async_create_entry(
-                    title="MeteoGalicia",
-                    data=_clean_data(user_input),
-                )
+                title = await _validated_title(self.hass, user_input, errors)
+                if title:
+                    return self.async_create_entry(
+                        title=title,
+                        data=_clean_data(user_input),
+                    )
 
         schema = vol.Schema(
             {
@@ -127,9 +270,7 @@ class MeteoGaliciaConfigFlow(config_entries.ConfigFlow, domain=const.DOMAIN):
             return self.async_abort(reason="invalid_import")
 
         id_concello = data.get(const.CONF_ID_CONCELLO)
-        if id_concello and (
-            len(id_concello) != 5 or not id_concello.isnumeric()
-        ):
+        if id_concello and (len(id_concello) != 5 or not id_concello.isnumeric()):
             return self.async_abort(reason="invalid_import")
         if not id_concello:
             id_estacion = data[const.CONF_ID_ESTACION]

--- a/custom_components/meteogalicia/const.py
+++ b/custom_components/meteogalicia/const.py
@@ -25,7 +25,11 @@ CONF_ID_ESTACION_MEDIDA_DAILY = "id_estacion_medida_diarios"
 CONF_ID_ESTACION_MEDIDA_LAST10MIN = "id_estacion_medida_ultimos_10_min"
 
 # Timeout por defecto
-TIMEOUT = 60 
+TIMEOUT = 60
+CONFIG_FLOW_TIMEOUT = 15
+STATIONS_URL = (
+    "https://servizos.meteogalicia.gal/mgrss/observacion/listaEstacionsMeteo.action"
+)
 
 # Mensajes de log (en inglés se mantienen claves, pero prefijados con LOG_PREFIX)
 STRING_NOT_UPDATE_SENSOR = f"{LOG_PREFIX} [%s] Couldn't update sensor (%s),%s"

--- a/custom_components/meteogalicia/coordinator.py
+++ b/custom_components/meteogalicia/coordinator.py
@@ -180,11 +180,16 @@ class BaseMeteoGaliciaCoordinator(DataUpdateCoordinator):
                     if not self._had_data_error:
                         _LOGGER.warning(self._warn_msg, self.id)
                     self._had_data_error = True
-                    return None
+                    raise UpdateFailed(
+                        f"MeteoGalicia no devolvió {self._error_context} "
+                        f"para {self.id}"
+                    )
                 if self._had_data_error:
                     _LOGGER.info(self._restore_msg, self.id)
                     self._had_data_error = False
                 return data
+        except UpdateFailed:
+            raise
         except Exception as err:  # pylint: disable=broad-except
             raise UpdateFailed(
                 f"Error obteniendo {self._error_context} para {self.id}: {err}"

--- a/custom_components/meteogalicia/coordinator.py
+++ b/custom_components/meteogalicia/coordinator.py
@@ -8,7 +8,6 @@ import logging
 import time
 from typing import Callable, Any
 
-import async_timeout
 import requests
 
 from homeassistant.core import HomeAssistant
@@ -172,7 +171,7 @@ class BaseMeteoGaliciaCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         try:
             async with self._session_lock:
-                async with async_timeout.timeout(const.TIMEOUT):
+                async with asyncio.timeout(const.TIMEOUT):
                     data = await _async_api_call_with_latency(
                         self, self._api_fn, self.id, self._session
                     )

--- a/custom_components/meteogalicia/manifest.json
+++ b/custom_components/meteogalicia/manifest.json
@@ -15,6 +15,6 @@
     "MeteoGalicia-API==0.1.2"
   ],
   "ssdp": [],
-  "version": "2026.08.1",
+  "version": "2026.08.2",
   "zeroconf": []
 }

--- a/custom_components/meteogalicia/translations/en.json
+++ b/custom_components/meteogalicia/translations/en.json
@@ -25,7 +25,11 @@
       }
     },
     "error": {
+      "cannot_connect": "Unable to connect to MeteoGalicia. Try again later.",
+      "timeout": "MeteoGalicia did not respond within the expected time.",
       "invalid_id": "The ID must be exactly 5 digits.",
+      "unknown_id": "MeteoGalicia does not recognize that identifier.",
+      "invalid_measure": "The station does not provide the selected measure.",
       "only_one_measure": "Only one measure can be used: daily or last 10 min."
     },
     "abort": {

--- a/custom_components/meteogalicia/translations/es.json
+++ b/custom_components/meteogalicia/translations/es.json
@@ -25,7 +25,11 @@
       }
     },
     "error": {
+      "cannot_connect": "No se puede conectar con MeteoGalicia. Inténtalo de nuevo más tarde.",
+      "timeout": "MeteoGalicia no respondió dentro del tiempo esperado.",
       "invalid_id": "El ID debe tener exactamente 5 digitos.",
+      "unknown_id": "MeteoGalicia no reconoce ese identificador.",
+      "invalid_measure": "La estación no ofrece la medida indicada.",
       "only_one_measure": "Solo puedes usar una medida: diaria o ultimos 10 min."
     },
     "abort": {

--- a/custom_components/meteogalicia/translations/gl.json
+++ b/custom_components/meteogalicia/translations/gl.json
@@ -25,8 +25,12 @@
       }
     },
     "error": {
+      "cannot_connect": "Non se pode conectar con MeteoGalicia. Téntao de novo máis tarde.",
+      "timeout": "MeteoGalicia non respondeu dentro do tempo esperado.",
       "only_one_measure": "So podes usar unha medida: diaria ou ultimos 10 min.",
-      "invalid_id": "O ID debe ter exactamente 5 díxitos."
+      "invalid_id": "O ID debe ter exactamente 5 díxitos.",
+      "unknown_id": "MeteoGalicia non recoñece ese identificador.",
+      "invalid_measure": "A estación non ofrece a medida indicada."
     },
     "abort": {
       "invalid_import": "A configuración YAML de MeteoGalicia non é válida."

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+asyncio_mode = auto

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
 homeassistant==2026.8.1
 MeteoGalicia-API==0.1.2
-pytest>=8.3,<10
-pytest-asyncio>=0.24,<2
-ruff>=0.12,<1
+pytest==9.1.1
+pytest-asyncio==1.4.0
+ruff==0.16.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,5 @@
+homeassistant==2026.8.1
+MeteoGalicia-API==0.1.2
+pytest>=8.3,<10
+pytest-asyncio>=0.24,<2
+ruff>=0.12,<1

--- a/tests/test_config_flow_validation.py
+++ b/tests/test_config_flow_validation.py
@@ -1,0 +1,80 @@
+"""Tests for config-flow API validation."""
+
+import pytest
+
+from custom_components.meteogalicia import config_flow, const
+
+
+def test_station_catalog_returns_requested_station():
+    station = config_flow._station_from_catalog(
+        {"listaEstacionsMeteo": [{"idEstacion": 10124, "estacion": "Santiago-EOAS"}]},
+        "10124",
+    )
+
+    assert station["estacion"] == "Santiago-EOAS"
+
+
+def test_station_catalog_rejects_unknown_identifier():
+    with pytest.raises(config_flow.InvalidIdentifier):
+        config_flow._station_from_catalog({"listaEstacionsMeteo": []}, "99999")
+
+
+def test_station_measure_parser_supports_last_10_min_payload():
+    name, measures = config_flow._station_name_and_measures(
+        {
+            "listUltimos10min": [
+                {
+                    "estacion": "Santiago-EOAS",
+                    "listaMedidas": [
+                        {"codigoParametro": "TA_AVG_1.5m"},
+                        {"codigoParametro": "DV_AVG_10m"},
+                    ],
+                }
+            ]
+        },
+        daily=False,
+    )
+
+    assert name == "Santiago-EOAS"
+    assert measures == {"TA_AVG_1.5m", "DV_AVG_10m"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exception", "error_key"),
+    [
+        (config_flow.CannotConnect(), "cannot_connect"),
+        (config_flow.RequestTimeout(), "timeout"),
+        (config_flow.InvalidIdentifier(), "unknown_id"),
+        (config_flow.InvalidMeasure(), "invalid_measure"),
+    ],
+)
+async def test_validation_errors_are_mapped(monkeypatch, exception, error_key):
+    async def raise_validation_error(_hass, _data):
+        raise exception
+
+    monkeypatch.setattr(
+        config_flow, "_async_validate_api_input", raise_validation_error
+    )
+    errors = {}
+
+    assert await config_flow._validated_title(object(), {}, errors) is None
+    assert errors == {"base": error_key}
+
+
+@pytest.mark.asyncio
+async def test_validation_returns_descriptive_title(monkeypatch):
+    async def validate(_hass, data):
+        assert data == {const.CONF_ID_CONCELLO: "15009"}
+        return "MeteoGalicia Betanzos"
+
+    monkeypatch.setattr(config_flow, "_async_validate_api_input", validate)
+    errors = {}
+
+    assert (
+        await config_flow._validated_title(
+            object(), {const.CONF_ID_CONCELLO: "15009"}, errors
+        )
+        == "MeteoGalicia Betanzos"
+    )
+    assert errors == {}

--- a/tests/test_coordinator_failures.py
+++ b/tests/test_coordinator_failures.py
@@ -1,0 +1,57 @@
+"""Tests for coordinator failures and recovery."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from custom_components.meteogalicia import coordinator as coordinator_module
+from custom_components.meteogalicia.coordinator import BaseMeteoGaliciaCoordinator
+
+
+def _coordinator_double():
+    return SimpleNamespace(
+        _session_lock=asyncio.Lock(),
+        _session=object(),
+        _api_fn=object(),
+        _error_context="datos de prueba",
+        _warn_msg="No hay datos para %s",
+        _restore_msg="Datos recuperados para %s",
+        _had_data_error=False,
+        id="15009",
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_response_is_a_failed_update(monkeypatch):
+    async def return_empty(*_args):
+        return None
+
+    monkeypatch.setattr(
+        coordinator_module, "_async_api_call_with_latency", return_empty
+    )
+    coordinator = _coordinator_double()
+
+    with pytest.raises(UpdateFailed, match="no devolvió"):
+        await BaseMeteoGaliciaCoordinator._async_update_data(coordinator)
+
+    assert coordinator._had_data_error is True
+
+
+@pytest.mark.asyncio
+async def test_success_after_empty_response_clears_error(monkeypatch):
+    payload = {"predConcello": {"nome": "Betanzos"}}
+
+    async def return_payload(*_args):
+        return payload
+
+    monkeypatch.setattr(
+        coordinator_module, "_async_api_call_with_latency", return_payload
+    )
+    coordinator = _coordinator_double()
+    coordinator._had_data_error = True
+
+    assert await BaseMeteoGaliciaCoordinator._async_update_data(coordinator) == payload
+    assert coordinator._had_data_error is False

--- a/tests/test_entry_reload.py
+++ b/tests/test_entry_reload.py
@@ -1,0 +1,24 @@
+"""Tests for config-entry option reloads."""
+
+import pytest
+
+from custom_components.meteogalicia import async_reload_entry
+
+
+@pytest.mark.asyncio
+async def test_options_update_reloads_entry():
+    calls = []
+
+    class ConfigEntries:
+        async def async_reload(self, entry_id):
+            calls.append(entry_id)
+
+    class Hass:
+        config_entries = ConfigEntries()
+
+    class Entry:
+        entry_id = "entry-id"
+
+    await async_reload_entry(Hass(), Entry())
+
+    assert calls == ["entry-id"]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,3 @@
-import types
 from datetime import datetime, timezone
 
 from custom_components.meteogalicia import sensor
@@ -45,15 +44,12 @@ def test_get_state_forecast_rain_by_day_sensor_max():
     assert sensor.get_state_forecast_rain_by_day_sensor(True, item) == 20
 
 
-def test_get_state_forecast_rain_by_day_sensor_slot():
+def test_get_state_forecast_rain_by_day_sensor_slot(monkeypatch):
     item = {"pchoiva": {"manha": 10, "tarde": 20, "noite": 5}}
     # For a fixed hour, simulate night slot
-    original_now = sensor.dt.now
-    sensor.dt.now = classmethod(lambda cls: datetime(2024, 1, 1, 23, 0))
-    try:
-        assert sensor.get_state_forecast_rain_by_day_sensor(False, item) == 5
-    finally:
-        sensor.dt.now = original_now
+    monkeypatch.setattr(sensor.dt, "now", lambda: datetime(2024, 1, 1, 23, 0))
+
+    assert sensor.get_state_forecast_rain_by_day_sensor(False, item) == 5
 
 
 def test_get_state_forecast_rain_by_day_sensor_invalid():


### PR DESCRIPTION
## Resumen

- recarga automáticamente cada entrada al guardar sus opciones, incluido `scan_interval`
- trata las respuestas vacías como actualizaciones fallidas para conservar los últimos datos válidos
- valida ayuntamientos contra el endpoint de previsión y estaciones contra el catálogo oficial antes de crear la entrada
- valida medidas cuando el endpoint tiene datos y evita rechazar estaciones válidas cuando los datos diarios están temporalmente vacíos
- usa el nombre real del ayuntamiento o estación como título de la entrada
- añade un workflow de pruebas con Home Assistant 2026.8.1, Python 3.14.2, `pytest`, validación JSON, compilación y Ruff
- fija por commit las acciones de HACS y hassfest y limita sus permisos a lectura
- actualiza documentación, traducciones y versión a `2026.08.2`

## Motivo

Los cambios del flujo de opciones no recargaban la integración, una respuesta vacía podía sustituir datos válidos y el formulario aceptaba identificadores solo por su formato. Además, las pruebas existentes no se ejecutaban en GitHub Actions.

## Validación local

- `python -m compileall -q custom_components tests`
- validación de todos los JSON
- `ruff check --select E9,F63,F7,F82 custom_components tests`
- `git diff --check`

El nuevo workflow ejecutará la batería completa de `pytest` con la versión publicada de Home Assistant.