### PR TITLE
Add typed station measures and observed weather

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Esta integración para [Home Assistant](https://www.home-assistant.io/) te permi
 Proporciona sensores y una entidad meteorológica:
 
 - Para un ayuntamiento dado
-  - Entidad `weather` con la temperatura observada, el estado del cielo previsto para la franja actual y la previsión diaria disponible (temperaturas máxima y mínima, probabilidad de lluvia e índice UV).
+  - Entidad `weather` con temperatura, sensación térmica y estado del cielo observados, además de la previsión diaria disponible (temperaturas máxima y mínima, probabilidad de lluvia e índice UV).
   - Observación meteorológica:
     - Temperatura actual.
   - Pronósticos:
@@ -30,9 +30,12 @@ Proporciona sensores y una entidad meteorológica:
       - Temperatura mínima
       - Probabilidad de lluvia
 - Para una estación meteorológica dada
-    -   Observación meteorológica
-        -  Ultimos datos diarios (10-minutales).
-        -  Datos diarios.
+  - Una entidad independiente por cada medida que ofrece la estación: temperatura,
+    humedad, presión, lluvia, radiación, velocidad y dirección del viento, entre otras.
+  - Medidas de los últimos 10 minutos y datos diarios, con unidad, clase de dispositivo
+    y clase de estado cuando Home Assistant dispone de una equivalencia nativa.
+  - Las entidades-resumen anteriores se conservan para no romper automatizaciones ni
+    perder la continuidad del historial.
   
   
 
@@ -91,7 +94,10 @@ No añadas nuevas configuraciones YAML: utiliza **Ajustes → Dispositivos y ser
 
 ## Diagnostics
 
-La integracion soporta diagnostics desde la UI para entradas creadas por config flow.
+La integración soporta diagnósticos desde la UI para entradas creadas por config flow.
+Incluyen el tipo de entrada, sus entidades y el estado de cada coordinador: último éxito,
+latencia, intervalo efectivo, disponibilidad y último error. Los payloads completos de la
+API no se incluyen.
 
 ## Autenticacion
 
@@ -105,8 +111,9 @@ MeteoGalicia no requiere autenticacion ni credenciales.
   - Max/Min hoy y manana
   - Probabilidad de lluvia hoy y manana
 - Estacion:
-  - Datos diarios (daily)
-  - Datos ultimos 10 min
+  - Una entidad por medida diaria disponible
+  - Una entidad por medida de los últimos 10 minutos disponible
+  - Sensores resumen heredados para compatibilidad
 
 
 ## FAQ

--- a/custom_components/meteogalicia/coordinator.py
+++ b/custom_components/meteogalicia/coordinator.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Coordinadores de actualización de datos para la integración MeteoGalicia."""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone, timedelta
@@ -11,9 +12,12 @@ from typing import Callable, Any
 import requests
 
 from homeassistant.core import HomeAssistant
+
 try:
     from homeassistant.helpers.entity_platform import DEFAULT_SCAN_INTERVAL
-except ImportError:  # pragma: no cover - compatibilidad para versiones nuevas/antiguas de HA
+except (
+    ImportError
+):  # pragma: no cover - compatibilidad para versiones nuevas/antiguas de HA
     try:
         from homeassistant.helpers.entity_component import DEFAULT_SCAN_INTERVAL
     except ImportError:  # pragma: no cover - último recurso
@@ -23,10 +27,6 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from . import const
 
 _LOGGER = logging.getLogger(__name__)
-
-# Sesión y cerrojo compartidos para todas las peticiones HTTP
-_SHARED_SESSION = requests.Session()
-_SHARED_SESSION_LOCK = asyncio.Lock()
 
 
 async def async_get_entry_coordinator(
@@ -42,15 +42,13 @@ async def async_get_entry_coordinator(
     the initialization task in the entry data makes both platforms await the same
     first refresh instead of creating duplicate API polling loops.
     """
-    entry_data = (
-        hass.data.setdefault(const.DOMAIN, {})
-        .setdefault(entry_id, {})
-    )
+    entry_data = hass.data.setdefault(const.DOMAIN, {}).setdefault(entry_id, {})
     tasks = entry_data.setdefault("coordinator_tasks", {})
     key = (coordinator_class.__name__, id_value)
     task = tasks.get(key)
 
     if task is None:
+
         async def _async_create_and_refresh():
             coordinator = coordinator_class(hass, id_value, scan_interval)
             coordinators = entry_data.setdefault("coordinators", [])
@@ -74,7 +72,9 @@ async def async_get_entry_coordinator(
         raise
 
 
-def _get_scan_interval(config_scan_interval: timedelta | int | float | None) -> timedelta:
+def _get_scan_interval(
+    config_scan_interval: timedelta | int | float | None,
+) -> timedelta:
     if isinstance(config_scan_interval, (int, float)):
         return timedelta(seconds=config_scan_interval)
     return config_scan_interval or DEFAULT_SCAN_INTERVAL
@@ -89,10 +89,14 @@ async def _async_api_call_with_latency(coordinator, api_call, *args):
         started = time.perf_counter()
         try:
             data = await coordinator.hass.async_add_executor_job(api_call, *args)
-            coordinator.last_api_latency_ms = round((time.perf_counter() - started) * 1000.0, 2)
+            coordinator.last_api_latency_ms = round(
+                (time.perf_counter() - started) * 1000.0, 2
+            )
             if data is not None:
                 # Precisión en segundos para lectura y comparaciones.
-                coordinator.last_api_connected_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+                coordinator.last_api_connected_at = datetime.now(
+                    timezone.utc
+                ).isoformat(timespec="seconds")
                 return data
             last_err = None
         except Exception as err:  # pylint: disable=broad-except
@@ -129,7 +133,9 @@ def _get_observation_dailydata_by_station_from_api(ids: str, session: requests.S
     return meteogalicia_api.get_observation_dailydata_by_station(ids)
 
 
-def _get_observation_last10mindata_by_station_from_api(ids: str, session: requests.Session):
+def _get_observation_last10mindata_by_station_from_api(
+    ids: str, session: requests.Session
+):
     """Llama a MeteoGalicia para obtener los últimos 10 minutos de una estación."""
     from meteogalicia_api.interface import MeteoGalicia
 
@@ -165,28 +171,28 @@ class BaseMeteoGaliciaCoordinator(DataUpdateCoordinator):
         self._had_data_error = False
         self.last_api_latency_ms = None
         self.last_api_connected_at = None
-        self._session = _SHARED_SESSION
-        self._session_lock = _SHARED_SESSION_LOCK
+        # Each coordinator owns its session. DataUpdateCoordinator already prevents
+        # overlapping refreshes for the same coordinator, while independent entries
+        # and endpoints can now update concurrently.
+        self._session = requests.Session()
 
     async def _async_update_data(self):
         try:
-            async with self._session_lock:
-                async with asyncio.timeout(const.TIMEOUT):
-                    data = await _async_api_call_with_latency(
-                        self, self._api_fn, self.id, self._session
-                    )
-                if data is None:
-                    if not self._had_data_error:
-                        _LOGGER.warning(self._warn_msg, self.id)
-                    self._had_data_error = True
-                    raise UpdateFailed(
-                        f"MeteoGalicia no devolvió {self._error_context} "
-                        f"para {self.id}"
-                    )
-                if self._had_data_error:
-                    _LOGGER.info(self._restore_msg, self.id)
-                    self._had_data_error = False
-                return data
+            async with asyncio.timeout(const.TIMEOUT):
+                data = await _async_api_call_with_latency(
+                    self, self._api_fn, self.id, self._session
+                )
+            if data is None:
+                if not self._had_data_error:
+                    _LOGGER.warning(self._warn_msg, self.id)
+                self._had_data_error = True
+                raise UpdateFailed(
+                    f"MeteoGalicia no devolvió {self._error_context} para {self.id}"
+                )
+            if self._had_data_error:
+                _LOGGER.info(self._restore_msg, self.id)
+                self._had_data_error = False
+            return data
         except UpdateFailed:
             raise
         except Exception as err:  # pylint: disable=broad-except
@@ -195,8 +201,8 @@ class BaseMeteoGaliciaCoordinator(DataUpdateCoordinator):
             ) from err
 
     async def async_close(self) -> None:
-        # No cerramos la sesión compartida aquí para evitar interferir con otros coordinadores.
-        return
+        """Close this coordinator's HTTP resources."""
+        await self.hass.async_add_executor_job(self._session.close)
 
 
 class MeteoGaliciaForecastCoordinator(BaseMeteoGaliciaCoordinator):

--- a/custom_components/meteogalicia/diagnostics.py
+++ b/custom_components/meteogalicia/diagnostics.py
@@ -1,17 +1,79 @@
 """Diagnostics support for MeteoGalicia."""
+
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import const
+
+
+def _serializable(value):
+    """Return a diagnostics-safe scalar value."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if hasattr(value, "value"):
+        return value.value
+    return str(value)
+
+
+def _coordinator_diagnostics(coordinator) -> dict:
+    """Return useful coordinator health without exposing API payloads."""
+    interval = getattr(coordinator, "update_interval", None)
+    return {
+        "class": coordinator.__class__.__name__,
+        "name": getattr(coordinator, "name", None),
+        "resource_id": getattr(coordinator, "id", None),
+        "last_update_success": bool(getattr(coordinator, "last_update_success", False)),
+        "last_successful_api_connection": getattr(
+            coordinator, "last_api_connected_at", None
+        ),
+        "last_api_latency_ms": getattr(coordinator, "last_api_latency_ms", None),
+        "scan_interval_seconds": (
+            interval.total_seconds() if interval is not None else None
+        ),
+        "last_error": _serializable(getattr(coordinator, "last_exception", None)),
+        "data_available": getattr(coordinator, "data", None) is not None,
+    }
+
+
+def _entry_type(entry: ConfigEntry) -> str:
+    """Return the configured MeteoGalicia resource type."""
+    data = {**entry.data, **entry.options}
+    if data.get(const.CONF_ID_CONCELLO):
+        return "municipality"
+    if data.get(const.CONF_ID_ESTACION):
+        return "station"
+    return "unknown"
 
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict:
     """Return diagnostics for a config entry."""
+    entry_data = hass.data.get(const.DOMAIN, {}).get(entry.entry_id, {})
+    registry = er.async_get(hass)
+    entities = er.async_entries_for_config_entry(registry, entry.entry_id)
     return {
         "entry": {
+            "entry_id": entry.entry_id,
+            "type": _entry_type(entry),
+            "title": entry.title,
             "data": dict(entry.data),
             "options": dict(entry.options),
-        }
+        },
+        "coordinators": [
+            _coordinator_diagnostics(coordinator)
+            for coordinator in entry_data.get("coordinators", [])
+        ],
+        "entities": [
+            {
+                "entity_id": entity.entity_id,
+                "unique_id": entity.unique_id,
+                "platform": entity.platform,
+                "disabled_by": _serializable(entity.disabled_by),
+            }
+            for entity in entities
+        ],
     }

--- a/custom_components/meteogalicia/manifest.json
+++ b/custom_components/meteogalicia/manifest.json
@@ -15,6 +15,6 @@
     "MeteoGalicia-API==0.1.2"
   ],
   "ssdp": [],
-  "version": "2026.08.2",
+  "version": "2026.08.3",
   "zeroconf": []
 }

--- a/custom_components/meteogalicia/sensor.py
+++ b/custom_components/meteogalicia/sensor.py
@@ -8,8 +8,13 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import (
     CONF_SCAN_INTERVAL,
+    DEGREE,
     PERCENTAGE,
     STATE_UNKNOWN,
+    UnitOfIrradiance,
+    UnitOfPrecipitationDepth,
+    UnitOfPressure,
+    UnitOfSpeed,
     UnitOfTemperature,
 )
 from homeassistant.exceptions import PlatformNotReady
@@ -22,6 +27,7 @@ from homeassistant.components.sensor import (
     PLATFORM_SCHEMA,
     SensorDeviceClass,
     SensorEntity,
+    SensorEntityDescription,
     SensorStateClass,
 )
 
@@ -265,6 +271,12 @@ async def setup_id_estacion_platform(
                     id_estacion, id_estacion, id_measure_daily, daily_coordinator
                 )
             )
+            if id_measure_daily is None:
+                entities.extend(
+                    _station_measure_entities(
+                        id_estacion, daily_coordinator, "daily"
+                    )
+                )
             _LOGGER.info(
                 "%s Añadidos datos diarios para '%s' con id '%s' - medida principal: %s",
                 const.LOG_PREFIX,
@@ -288,6 +300,12 @@ async def setup_id_estacion_platform(
                     id_estacion, id_estacion, id_measure_last10min, last10min_coordinator
                 )
             )
+            if id_measure_last10min is None:
+                entities.extend(
+                    _station_measure_entities(
+                        id_estacion, last10min_coordinator, "last_10_min"
+                    )
+                )
             _LOGGER.info(
                 "%s Añadidos datos de los últimos 10 min para '%s' con id '%s' - medida principal: %s",
                 const.LOG_PREFIX,
@@ -837,6 +855,162 @@ class MeteoGaliciaLast10MinDataByStationSensor(BaseStationSensor):  # pylint: di
             "estacion": item.get("estacion"),
         }
         return item, lista_medidas, extra, None
+
+
+_STATION_SOURCE_CONFIG = {
+    "daily": {
+        "translation_key": "station_measure_daily",
+        "payload_key": "listDatosDiarios",
+    },
+    "last_10_min": {
+        "translation_key": "station_measure_last_10_min",
+        "payload_key": "listUltimos10min",
+    },
+}
+
+
+def _station_source(data: dict, source: str) -> tuple[dict | None, list[dict]]:
+    """Return the station record and measures for one API source."""
+    source_config = _STATION_SOURCE_CONFIG[source]
+    item = _get_first_list_item(data, source_config["payload_key"])
+    if item is None:
+        return None, []
+    station = (
+        _get_first_list_item(item, "listaEstacions")
+        if source == "daily"
+        else item
+    )
+    if not isinstance(station, dict):
+        return None, []
+    measures = station.get("listaMedidas")
+    return station, measures if isinstance(measures, list) else []
+
+
+def _normalise_station_unit(unit: str | None) -> str | None:
+    """Convert MeteoGalicia unit spellings to Home Assistant native units."""
+    return {
+        "ºC": UnitOfTemperature.CELSIUS,
+        "°C": UnitOfTemperature.CELSIUS,
+        "º": DEGREE,
+        "°": DEGREE,
+        "L/m2": UnitOfPrecipitationDepth.MILLIMETERS,
+        "L/m²": UnitOfPrecipitationDepth.MILLIMETERS,
+        "hPa": UnitOfPressure.HPA,
+        "m/s": UnitOfSpeed.METERS_PER_SECOND,
+        "km/h": UnitOfSpeed.KILOMETERS_PER_HOUR,
+        "W/m2": UnitOfIrradiance.WATTS_PER_SQUARE_METER,
+        "W/m²": UnitOfIrradiance.WATTS_PER_SQUARE_METER,
+    }.get(unit, unit)
+
+
+def _station_measure_device_class(code: str) -> SensorDeviceClass | None:
+    """Map well-known MeteoGalicia parameter families to HA device classes."""
+    prefix = code.split("_", 1)[0]
+    return {
+        "HR": SensorDeviceClass.HUMIDITY,
+        "PP": SensorDeviceClass.PRECIPITATION,
+        "PR": SensorDeviceClass.ATMOSPHERIC_PRESSURE,
+        "PRED": SensorDeviceClass.ATMOSPHERIC_PRESSURE,
+        "RD": SensorDeviceClass.IRRADIANCE,
+        "RS": SensorDeviceClass.IRRADIANCE,
+        "TA": SensorDeviceClass.TEMPERATURE,
+        "TO": SensorDeviceClass.TEMPERATURE,
+        "TS": SensorDeviceClass.TEMPERATURE,
+        "VV": SensorDeviceClass.WIND_SPEED,
+    }.get(prefix)
+
+
+def _station_measure_description(
+    measure: dict, source: str
+) -> SensorEntityDescription:
+    """Build a typed description for a station measure returned by the API."""
+    code = str(measure.get("codigoParametro") or "unknown")
+    name = str(measure.get("nomeParametro") or code)
+    return SensorEntityDescription(
+        key=f"{source}_{code}",
+        translation_key=_STATION_SOURCE_CONFIG[source]["translation_key"],
+        translation_placeholders={"measure": name},
+        native_unit_of_measurement=_normalise_station_unit(measure.get("unidade")),
+        device_class=_station_measure_device_class(code),
+        state_class=(
+            SensorStateClass.TOTAL
+            if "_SUM_" in code
+            else SensorStateClass.MEASUREMENT
+        ),
+    )
+
+
+def _valid_station_measure_value(measure: dict | None):
+    """Return only original or interpolated station measurements."""
+    if not isinstance(measure, dict):
+        return None
+    value = measure.get("valor")
+    if measure.get("lnCodigoValidacion") not in (1, 5) or value == -9999:
+        return None
+    return value
+
+
+class MeteoGaliciaStationMeasureSensor(
+    MeteoGaliciaExtraAttrsMixin, CoordinatorEntity, SensorEntity
+):
+    """One typed Home Assistant entity for one station measurement."""
+
+    _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
+
+    def __init__(self, station_id, station_name, source, measure, coordinator):
+        self.entity_description = _station_measure_description(measure, source)
+        super().__init__(coordinator)
+        self._station_id = station_id
+        self._source = source
+        self._measure_code = str(measure.get("codigoParametro"))
+        self._attr_unique_id = (
+            f"meteogalicia_station_{station_id}_{source}_{self._measure_code}"
+        )
+        self._attr_device_info = _build_device_info(
+            f"station_{station_id}", station_name
+        )
+        self._attr = _base_attrs(station_id)
+
+    @property
+    def available(self) -> bool:
+        """Return whether the coordinator and this measurement are available."""
+        return self.coordinator.last_update_success and self.native_value is not None
+
+    @property
+    def native_value(self):
+        """Return the current value for this entity's measure code."""
+        _, measures = _station_source(self.coordinator.data, self._source)
+        measure = next(
+            (
+                item
+                for item in measures
+                if item.get("codigoParametro") == self._measure_code
+            ),
+            None,
+        )
+        return _valid_station_measure_value(measure)
+
+
+def _station_measure_entities(station_id, coordinator, source):
+    """Create one entity per distinct measure while preserving legacy sensors."""
+    station, measures = _station_source(coordinator.data, source)
+    if station is None:
+        return []
+    station_name = station.get("estacion", station_id)
+    entities = []
+    seen_codes = set()
+    for measure in measures:
+        code = measure.get("codigoParametro")
+        if not code or code in seen_codes:
+            continue
+        seen_codes.add(code)
+        entities.append(
+            MeteoGaliciaStationMeasureSensor(
+                station_id, station_name, source, measure, coordinator
+            )
+        )
+    return entities
 
 
 

--- a/custom_components/meteogalicia/translations/en.json
+++ b/custom_components/meteogalicia/translations/en.json
@@ -42,6 +42,16 @@
       "description": "The MeteoGalicia YAML configuration for `{identifier}` was successfully imported as a config entry. Remove this block from `configuration.yaml` and restart Home Assistant:\n\n```yaml\n{configuration}\n```\n\nThe imported entry keeps the entity identifiers and update interval. This notification will disappear after the block is removed and Home Assistant is restarted."
     }
   },
+  "entity": {
+    "sensor": {
+      "station_measure_daily": {
+        "name": "Daily {measure}"
+      },
+      "station_measure_last_10_min": {
+        "name": "Last 10 min {measure}"
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/meteogalicia/translations/es.json
+++ b/custom_components/meteogalicia/translations/es.json
@@ -42,6 +42,16 @@
       "description": "La configuración YAML de MeteoGalicia para `{identifier}` se ha importado correctamente como una entrada de configuración. Elimina este bloque de `configuration.yaml` y reinicia Home Assistant:\n\n```yaml\n{configuration}\n```\n\nLa entrada importada conserva los identificadores de las entidades y el intervalo de actualización. Este aviso desaparecerá después de retirar el bloque y reiniciar."
     }
   },
+  "entity": {
+    "sensor": {
+      "station_measure_daily": {
+        "name": "{measure} diaria"
+      },
+      "station_measure_last_10_min": {
+        "name": "{measure} de los últimos 10 min"
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/meteogalicia/translations/gl.json
+++ b/custom_components/meteogalicia/translations/gl.json
@@ -42,6 +42,16 @@
       "description": "A configuración YAML de MeteoGalicia para `{identifier}` importouse correctamente como unha entrada de configuración. Elimina este bloque de `configuration.yaml` e reinicia Home Assistant:\n\n```yaml\n{configuration}\n```\n\nA entrada importada conserva os identificadores das entidades e o intervalo de actualización. Este aviso desaparecerá despois de retirar o bloque e reiniciar."
     }
   },
+  "entity": {
+    "sensor": {
+      "station_measure_daily": {
+        "name": "{measure} diaria"
+      },
+      "station_measure_last_10_min": {
+        "name": "{measure} dos últimos 10 min"
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/meteogalicia/weather.py
+++ b/custom_components/meteogalicia/weather.py
@@ -1,4 +1,5 @@
 """Weather entity for the MeteoGalicia integration."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -8,7 +9,6 @@ from homeassistant.const import CONF_SCAN_INTERVAL, UnitOfTemperature
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import dt as dt_util
 
 from . import const
 from .coordinator import (
@@ -71,16 +71,6 @@ def _condition_from_code(value: Any) -> str | None:
     return _CONDITION_BY_CODE.get(code % 100)
 
 
-def _time_period() -> str:
-    """Return the MeteoGalicia period for the current local time."""
-    hour = dt_util.now().hour
-    if 6 <= hour < 14:
-        return "manha"
-    if 14 <= hour < 21:
-        return "tarde"
-    return "noite"
-
-
 def _valid_value(value: Any) -> Any:
     """Return None for MeteoGalicia's unavailable sentinel."""
     return None if value == -9999 else value
@@ -108,6 +98,31 @@ def _forecast_days(data: dict[str, Any] | None) -> list[dict[str, Any]]:
         return []
     days = pred_concello.get("listaPredDiaConcello")
     return days if isinstance(days, list) else []
+
+
+def _current_observation(data: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Extract the latest measured municipal observation."""
+    if not isinstance(data, dict):
+        return None
+    observations = data.get("listaObservacionConcellos")
+    if not isinstance(observations, list) or not observations:
+        return None
+    observation = observations[0]
+    return observation if isinstance(observation, dict) else None
+
+
+def _observation_float(data: dict[str, Any] | None, key: str) -> float | None:
+    """Return a numeric measured observation, ignoring unavailable values."""
+    observation = _current_observation(data)
+    if observation is None:
+        return None
+    value = observation.get(key)
+    if value in (None, -9999):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _weather_unique_id(id_concello: str) -> str:
@@ -186,38 +201,30 @@ class MeteoGaliciaWeather(CoordinatorEntity, WeatherEntity):
         """Subscribe to measured-observation updates."""
         await super().async_added_to_hass()
         self.async_on_remove(
-            self._observation_coordinator.async_add_listener(
-                self.async_write_ha_state
-            )
+            self._observation_coordinator.async_add_listener(self.async_write_ha_state)
         )
 
     @property
     def native_temperature(self) -> float | None:
         """Return the latest temperature actually observed for the municipality."""
-        data = self._observation_coordinator.data
-        if not isinstance(data, dict):
-            return None
-        observations = data.get("listaObservacionConcellos")
-        if not isinstance(observations, list) or not observations:
-            return None
-        temperature = observations[0].get("temperatura")
-        if temperature in (None, -9999):
-            return None
-        try:
-            return float(temperature)
-        except (TypeError, ValueError):
-            return None
+        return _observation_float(self._observation_coordinator.data, "temperatura")
+
+    @property
+    def native_apparent_temperature(self) -> float | None:
+        """Return the latest apparent temperature actually observed."""
+        return _observation_float(
+            self._observation_coordinator.data, "sensacionTermica"
+        )
 
     @property
     def condition(self) -> str | None:
-        """Return the condition for the current part of today."""
-        days = _forecast_days(self.coordinator.data)
-        if not days:
-            return None
-        sky = days[0].get("ceo")
-        if isinstance(sky, dict):
-            return _condition_from_code(sky.get(_time_period()))
-        return _condition_from_code(days[0].get("ceoDia"))
+        """Return the latest sky condition actually observed."""
+        observation = _current_observation(self._observation_coordinator.data)
+        return (
+            _condition_from_code(observation.get("icoEstadoCeo"))
+            if observation is not None
+            else None
+        )
 
     async def async_forecast_daily(self) -> list[dict[str, Any]] | None:
         """Return the daily forecast."""

--- a/tests/test_coordinator_failures.py
+++ b/tests/test_coordinator_failures.py
@@ -13,7 +13,6 @@ from custom_components.meteogalicia.coordinator import BaseMeteoGaliciaCoordinat
 
 def _coordinator_double():
     return SimpleNamespace(
-        _session_lock=asyncio.Lock(),
         _session=object(),
         _api_fn=object(),
         _error_context="datos de prueba",
@@ -55,3 +54,46 @@ async def test_success_after_empty_response_clears_error(monkeypatch):
 
     assert await BaseMeteoGaliciaCoordinator._async_update_data(coordinator) == payload
     assert coordinator._had_data_error is False
+
+
+@pytest.mark.asyncio
+async def test_independent_coordinators_are_not_globally_serialized(monkeypatch):
+    running = 0
+    maximum_running = 0
+
+    async def concurrent_call(*_args):
+        nonlocal running, maximum_running
+        running += 1
+        maximum_running = max(maximum_running, running)
+        await asyncio.sleep(0)
+        running -= 1
+        return {"data": True}
+
+    monkeypatch.setattr(
+        coordinator_module, "_async_api_call_with_latency", concurrent_call
+    )
+
+    await asyncio.gather(
+        BaseMeteoGaliciaCoordinator._async_update_data(_coordinator_double()),
+        BaseMeteoGaliciaCoordinator._async_update_data(_coordinator_double()),
+    )
+
+    assert maximum_running == 2
+
+
+@pytest.mark.asyncio
+async def test_coordinator_closes_its_own_session_in_executor():
+    closed = []
+    session = SimpleNamespace(close=lambda: closed.append(True))
+
+    async def executor_job(callback):
+        callback()
+
+    coordinator = SimpleNamespace(
+        hass=SimpleNamespace(async_add_executor_job=executor_job),
+        _session=session,
+    )
+
+    await BaseMeteoGaliciaCoordinator.async_close(coordinator)
+
+    assert closed == [True]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,51 @@
+"""Tests for MeteoGalicia config-entry diagnostics."""
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.meteogalicia import diagnostics
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_include_health_interval_errors_and_entities(monkeypatch):
+    coordinator = SimpleNamespace(
+        name="meteogalicia_observation_15009",
+        id="15009",
+        update_interval=timedelta(seconds=1800),
+        last_update_success=False,
+        last_api_connected_at="2026-08-08T16:17:00+00:00",
+        last_api_latency_ms=243.2,
+        last_exception=TimeoutError("API timeout"),
+        data={"private_payload": "not exposed"},
+    )
+    entry = SimpleNamespace(
+        entry_id="entry-1",
+        title="Betanzos",
+        data={"id_concello": "15009"},
+        options={"scan_interval": 1800},
+    )
+    entity = SimpleNamespace(
+        entity_id="weather.betanzos",
+        unique_id="meteogalicia_weather_15009",
+        platform="meteogalicia",
+        disabled_by=None,
+    )
+    hass = SimpleNamespace(
+        data={"meteogalicia": {"entry-1": {"coordinators": [coordinator]}}}
+    )
+    monkeypatch.setattr(diagnostics.er, "async_get", lambda _hass: object())
+    monkeypatch.setattr(
+        diagnostics.er,
+        "async_entries_for_config_entry",
+        lambda _registry, _entry_id: [entity],
+    )
+
+    result = await diagnostics.async_get_config_entry_diagnostics(hass, entry)
+
+    assert result["entry"]["type"] == "municipality"
+    assert result["coordinators"][0]["scan_interval_seconds"] == 1800
+    assert result["coordinators"][0]["last_error"] == "API timeout"
+    assert result["entities"][0]["entity_id"] == "weather.betanzos"
+    assert "private_payload" not in str(result)

--- a/tests/test_station_measure_entities.py
+++ b/tests/test_station_measure_entities.py
@@ -1,0 +1,193 @@
+"""Tests for typed station measurement entities."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import (
+    UnitOfIrradiance,
+    UnitOfPrecipitationDepth,
+    UnitOfPressure,
+    UnitOfSpeed,
+    UnitOfTemperature,
+)
+
+from custom_components.meteogalicia.sensor import (
+    _station_measure_description,
+    _station_measure_entities,
+    setup_id_estacion_platform,
+)
+
+
+def _measure(code, name, unit, value=1, validation=1):
+    return {
+        "codigoParametro": code,
+        "nomeParametro": name,
+        "unidade": unit,
+        "valor": value,
+        "lnCodigoValidacion": validation,
+    }
+
+
+def test_measure_descriptions_map_native_home_assistant_metadata():
+    cases = [
+        ("TA_AVG_1.5m", "ºC", SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS),
+        ("HR_AVG_1.5m", "%", SensorDeviceClass.HUMIDITY, "%"),
+        (
+            "PR_AVG_1.5m",
+            "hPa",
+            SensorDeviceClass.ATMOSPHERIC_PRESSURE,
+            UnitOfPressure.HPA,
+        ),
+        (
+            "PP_SUM_1.5m",
+            "L/m2",
+            SensorDeviceClass.PRECIPITATION,
+            UnitOfPrecipitationDepth.MILLIMETERS,
+        ),
+        (
+            "RS_AVG_1.5m",
+            "W/m2",
+            SensorDeviceClass.IRRADIANCE,
+            UnitOfIrradiance.WATTS_PER_SQUARE_METER,
+        ),
+        (
+            "VV_AVG_10m",
+            "m/s",
+            SensorDeviceClass.WIND_SPEED,
+            UnitOfSpeed.METERS_PER_SECOND,
+        ),
+    ]
+
+    for code, unit, device_class, native_unit in cases:
+        description = _station_measure_description(
+            _measure(code, code, unit), "last_10_min"
+        )
+        assert description.device_class == device_class
+        assert description.native_unit_of_measurement == native_unit
+
+    total = _station_measure_description(
+        _measure("PP_SUM_1.5m", "Chuvia", "L/m2"), "daily"
+    )
+    assert total.state_class == SensorStateClass.TOTAL
+    assert total.translation_key == "station_measure_daily"
+
+
+def test_station_measure_entities_are_stable_and_follow_updates():
+    payload = {
+        "listUltimos10min": [
+            {
+                "estacion": "Santiago-EOAS",
+                "listaMedidas": [
+                    _measure("TA_AVG_1.5m", "Temperatura", "ºC", 20.5),
+                    _measure("HR_AVG_1.5m", "Humidade", "%", -9999, 9),
+                ],
+            }
+        ]
+    }
+    coordinator = SimpleNamespace(data=payload, last_update_success=True)
+
+    entities = _station_measure_entities("10124", coordinator, "last_10_min")
+
+    assert len(entities) == 2
+    assert entities[0].unique_id == (
+        "meteogalicia_station_10124_last_10_min_TA_AVG_1.5m"
+    )
+    assert entities[0].native_value == 20.5
+    assert entities[0].available is True
+    assert entities[1].native_value is None
+    assert entities[1].available is False
+
+    payload["listUltimos10min"][0]["listaMedidas"][0]["valor"] = 21.0
+    assert entities[0].native_value == 21.0
+
+
+def test_duplicate_measure_codes_create_only_one_entity():
+    duplicate = _measure("TA_AVG_1.5m", "Temperatura", "ºC")
+    coordinator = SimpleNamespace(
+        data={
+            "listDatosDiarios": [
+                {
+                    "listaEstacions": [
+                        {
+                            "estacion": "Santiago-EOAS",
+                            "listaMedidas": [duplicate, duplicate],
+                        }
+                    ]
+                }
+            ]
+        },
+        last_update_success=True,
+    )
+
+    assert len(_station_measure_entities("10124", coordinator, "daily")) == 1
+
+
+@pytest.mark.asyncio
+async def test_station_setup_keeps_legacy_summaries_and_adds_measure_entities(
+    monkeypatch,
+):
+    daily_payload = {
+        "listDatosDiarios": [
+            {
+                "listaEstacions": [
+                    {
+                        "estacion": "Santiago-EOAS",
+                        "listaMedidas": [
+                            _measure("TA_AVG_1.5m", "Temperatura", "ºC", 20.5)
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+    last_10_payload = {
+        "listUltimos10min": [
+            {
+                "estacion": "Santiago-EOAS",
+                "listaMedidas": [_measure("HR_AVG_1.5m", "Humidade", "%", 70)],
+            }
+        ]
+    }
+
+    class FakeCoordinator:
+        payload = None
+
+        def __init__(self, _hass, _station_id, _scan_interval):
+            self.data = self.payload
+            self.last_update_success = True
+            self.last_api_connected_at = None
+            self.last_api_latency_ms = None
+            self.update_interval = None
+
+        async def async_refresh(self):
+            return None
+
+        def async_set_updated_data(self, data):
+            self.data = data
+
+    class DailyCoordinator(FakeCoordinator):
+        payload = daily_payload
+
+    class Last10Coordinator(FakeCoordinator):
+        payload = last_10_payload
+
+    from custom_components.meteogalicia import sensor
+
+    monkeypatch.setattr(sensor, "MeteoGaliciaStationDailyCoordinator", DailyCoordinator)
+    monkeypatch.setattr(
+        sensor, "MeteoGaliciaStationLast10MinCoordinator", Last10Coordinator
+    )
+    added = []
+
+    await setup_id_estacion_platform("10124", {}, added.extend, object(), 1800, [])
+
+    assert len(added) == 4
+    assert (
+        sum(
+            entity.__class__.__name__ == "MeteoGaliciaStationMeasureSensor"
+            for entity in added
+        )
+        == 2
+    )

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,9 +1,9 @@
 """Tests for the MeteoGalicia weather entity helpers."""
+
 from types import SimpleNamespace
 
 import pytest
 
-from custom_components.meteogalicia import weather
 from custom_components.meteogalicia.weather import (
     MeteoGaliciaWeather,
     _condition_from_code,
@@ -51,6 +51,24 @@ def test_native_temperature_uses_observed_value():
     assert entity.native_temperature == pytest.approx(18.4)
 
 
+def test_apparent_temperature_and_condition_use_observed_values():
+    entity = _weather_without_init(
+        {
+            "listaObservacionConcellos": [
+                {
+                    "temperatura": 18.4,
+                    "sensacionTermica": "17.8",
+                    "icoEstadoCeo": 111,
+                }
+            ]
+        },
+        forecast_data={"predConcello": {"listaPredDiaConcello": [{"ceoDia": 101}]}},
+    )
+
+    assert entity.native_apparent_temperature == pytest.approx(17.8)
+    assert entity.condition == "rainy"
+
+
 @pytest.mark.parametrize(
     "payload",
     [
@@ -65,19 +83,19 @@ def test_native_temperature_handles_unavailable_observations(payload):
     assert _weather_without_init(payload).native_temperature is None
 
 
-def test_current_condition_uses_forecast_time_period(monkeypatch):
+def test_current_condition_does_not_fall_back_to_forecast():
     entity = _weather_without_init(
+        observation_data={},
         forecast_data={
             "predConcello": {
                 "listaPredDiaConcello": [
                     {"ceo": {"manha": 101, "tarde": 111, "noite": 203}}
                 ]
             }
-        }
+        },
     )
-    monkeypatch.setattr(weather, "_time_period", lambda: "tarde")
 
-    assert entity.condition == "rainy"
+    assert entity.condition is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Resumen

- crea una entidad `sensor` independiente y tipada por cada medida de estación, manteniendo los sensores-resumen y sus `unique_id` heredados
- usa observaciones reales para la temperatura, sensación térmica y condición actual de `weather`; la previsión diaria sigue usando el endpoint de forecast
- elimina el bloqueo HTTP global mediante una sesión propia por coordinador
- amplía los diagnósticos con estado, último éxito/error, latencia, intervalo efectivo, tipo de entrada y entidades
- moderniza las nuevas entidades con `SensorEntityDescription`, nombres traducibles y unidades/clases nativas
- prepara la versión `2026.08.3`

Relacionado con #19.

## Validación

- Home Assistant 2026.8.1
- Python 3.14
- `ruff check --select E9,F63,F7,F82 custom_components tests`
- `pytest -q`: 49 passed
- validación de sintaxis y JSON