### PR TITLE
Add observation freshness and integration coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,15 @@ jobs:
           cache-dependency-path: requirements_test.txt
 
       - name: Install test dependencies
-        run: python -m pip install -r requirements_test.txt
+        run: >-
+          python -m pip install
+          homeassistant==2026.8.1
+          MeteoGalicia-API==0.1.2
+          pytest==9.0.3
+          pytest-asyncio==1.4.0
+          pytest-cov==7.1.0
+          pytest-homeassistant-custom-component==0.13.355
+          ruff==0.16.2
 
       - name: Validate Python syntax
         run: python -m compileall -q custom_components tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,13 @@ permissions:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - name: Check out repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -22,13 +26,7 @@ jobs:
           cache-dependency-path: requirements_test.txt
 
       - name: Install test dependencies
-        run: >-
-          python -m pip install
-          homeassistant==2026.8.1
-          MeteoGalicia-API==0.1.2
-          pytest==9.1.1
-          pytest-asyncio==1.4.0
-          ruff==0.16.2
+        run: python -m pip install -r requirements_test.txt
 
       - name: Validate Python syntax
         run: python -m compileall -q custom_components tests
@@ -42,4 +40,13 @@ jobs:
         run: ruff check --select E9,F63,F7,F82 custom_components tests
 
       - name: Run unit tests
-        run: pytest -q
+        run: >-
+          pytest -q
+          --cov=custom_components/meteogalicia
+          --cov-report=term-missing
+          --cov-report=xml
+          --cov-fail-under=70
+
+      - name: Publish coverage to SonarQube Cloud
+        if: env.SONAR_TOKEN != ''
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .tmp_pypi/
+.coverage
+coverage.xml
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ No añadas nuevas configuraciones YAML: utiliza **Ajustes → Dispositivos y ser
 - Puedes tener varias entradas del mismo tipo y cada una puede usar un intervalo distinto.
 - Si MeteoGalicia devuelve temporalmente una respuesta vacía, se conservan los últimos
   datos válidos y la actualización se marca como fallida hasta que el servicio se recupere.
+- Las observaciones incluyen la marca temporal real devuelta por MeteoGalicia, su
+  antigüedad en segundos y un indicador `data_stale`/`observation_stale` cuando el
+  dato supera dos intervalos de actualización (mínimo 30 minutos). Para los datos
+  diarios se utiliza un umbral de 48 horas.
 
 ## Diagnostics
 
@@ -98,6 +102,12 @@ La integración soporta diagnósticos desde la UI para entradas creadas por conf
 Incluyen el tipo de entrada, sus entidades y el estado de cada coordinador: último éxito,
 latencia, intervalo efectivo, disponibilidad y último error. Los payloads completos de la
 API no se incluyen.
+
+## Pruebas y cobertura
+
+La integración se prueba con una instancia real de Home Assistant 2026.8.1 además
+de las pruebas unitarias. CI genera `coverage.xml`, exige al menos un 70 % de cobertura
+y lo publica en SonarQube Cloud cuando el repositorio dispone de `SONAR_TOKEN`.
 
 ## Autenticacion
 

--- a/custom_components/meteogalicia/const.py
+++ b/custom_components/meteogalicia/const.py
@@ -39,3 +39,6 @@ STRING_MEASURE_NOT_AVAILABLE = f"{LOG_PREFIX} Couldn't update sensor with measur
 ATTR_CONNECTED_AT = "connected_at"
 ATTR_API_LATENCY_MS = "api_latency_ms"
 ATTR_SCAN_INTERVAL_S = "scan_interval_s"
+ATTR_DATA_TIMESTAMP = "data_timestamp"
+ATTR_DATA_AGE_S = "data_age_s"
+ATTR_DATA_STALE = "data_stale"

--- a/custom_components/meteogalicia/coordinator.py
+++ b/custom_components/meteogalicia/coordinator.py
@@ -28,6 +28,52 @@ from . import const
 
 _LOGGER = logging.getLogger(__name__)
 
+_MIN_RECENT_DATA_MAX_AGE = timedelta(minutes=30)
+_DAILY_DATA_MAX_AGE = timedelta(hours=48)
+
+
+def _utcnow() -> datetime:
+    """Return the current UTC time for freshness calculations."""
+    return datetime.now(timezone.utc)
+
+
+def _parse_api_timestamp(value: Any) -> datetime | None:
+    """Parse MeteoGalicia timestamps, whose UTC values omit the offset."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _first_mapping(data: dict, key: str) -> dict | None:
+    """Return the first mapping from a payload list."""
+    if not isinstance(data, dict):
+        return None
+    items = data.get(key)
+    if not isinstance(items, list) or not items or not isinstance(items[0], dict):
+        return None
+    return items[0]
+
+
+def _observation_timestamp(data: dict) -> Any:
+    observation = _first_mapping(data, "listaObservacionConcellos")
+    return observation.get("dataUTC") if observation else None
+
+
+def _station_daily_timestamp(data: dict) -> Any:
+    day = _first_mapping(data, "listDatosDiarios")
+    return day.get("data") if day else None
+
+
+def _station_last10_timestamp(data: dict) -> Any:
+    observation = _first_mapping(data, "listUltimos10min")
+    return observation.get("instanteLecturaUTC") if observation else None
+
 
 async def async_get_entry_coordinator(
     hass: HomeAssistant,
@@ -156,6 +202,8 @@ class BaseMeteoGaliciaCoordinator(DataUpdateCoordinator):
         warn_msg: str,
         restore_msg: str,
         error_context: str,
+        data_timestamp_fn: Callable[[dict], Any] | None = None,
+        data_max_age: timedelta | None = None,
     ) -> None:
         super().__init__(
             hass,
@@ -171,10 +219,65 @@ class BaseMeteoGaliciaCoordinator(DataUpdateCoordinator):
         self._had_data_error = False
         self.last_api_latency_ms = None
         self.last_api_connected_at = None
+        self.data_timestamp = None
+        self._data_timestamp_utc = None
+        self._data_timestamp_fn = data_timestamp_fn
+        self._data_max_age = data_max_age
+        self._last_stale_state = None
         # Each coordinator owns its session. DataUpdateCoordinator already prevents
         # overlapping refreshes for the same coordinator, while independent entries
         # and endpoints can now update concurrently.
         self._session = requests.Session()
+
+    @property
+    def data_age_seconds(self) -> float | None:
+        """Return the age of the actual MeteoGalicia observation."""
+        if self._data_timestamp_utc is None:
+            return None
+        return round(
+            max(0.0, (_utcnow() - self._data_timestamp_utc).total_seconds()),
+            1,
+        )
+
+    @property
+    def data_is_stale(self) -> bool | None:
+        """Return whether the actual observation is older than expected."""
+        age = self.data_age_seconds
+        if age is None:
+            return None
+        max_age = self._data_max_age or max(
+            _MIN_RECENT_DATA_MAX_AGE,
+            self.update_interval * 2,
+        )
+        return age > max_age.total_seconds()
+
+    def _check_staleness_transition(self) -> None:
+        """Log only when measured data becomes stale or recovers."""
+        stale = self.data_is_stale
+        if stale is True and self._last_stale_state is not True:
+            _LOGGER.warning(
+                "[%s] Los datos medidos de MeteoGalicia están obsoletos "
+                "(marca temporal: %s, antigüedad: %s s)",
+                self.id,
+                self.data_timestamp,
+                self.data_age_seconds,
+            )
+        elif stale is False and self._last_stale_state is True:
+            _LOGGER.info(
+                "[%s] MeteoGalicia vuelve a proporcionar datos recientes", self.id
+            )
+        self._last_stale_state = stale
+
+    def _update_data_timestamp(self, data: dict) -> None:
+        """Store the real observation time returned by MeteoGalicia."""
+        if self._data_timestamp_fn is None:
+            return
+        timestamp = _parse_api_timestamp(self._data_timestamp_fn(data))
+        self._data_timestamp_utc = timestamp
+        self.data_timestamp = (
+            timestamp.isoformat(timespec="seconds") if timestamp else None
+        )
+        self._check_staleness_transition()
 
     async def _async_update_data(self):
         try:
@@ -192,10 +295,13 @@ class BaseMeteoGaliciaCoordinator(DataUpdateCoordinator):
             if self._had_data_error:
                 _LOGGER.info(self._restore_msg, self.id)
                 self._had_data_error = False
+            self._update_data_timestamp(data)
             return data
         except UpdateFailed:
+            self._check_staleness_transition()
             raise
         except Exception as err:  # pylint: disable=broad-except
+            self._check_staleness_transition()
             raise UpdateFailed(
                 f"Error obteniendo {self._error_context} para {self.id}: {err}"
             ) from err
@@ -234,6 +340,7 @@ class MeteoGaliciaObservationCoordinator(BaseMeteoGaliciaCoordinator):
             warn_msg="[%s] Posible problema de conexión. No se pueden descargar datos de observación de MeteoGalicia",
             restore_msg="[%s] Datos de observación recuperados tras el error previo",
             error_context="datos de observación",
+            data_timestamp_fn=_observation_timestamp,
         )
 
 
@@ -250,6 +357,8 @@ class MeteoGaliciaStationDailyCoordinator(BaseMeteoGaliciaCoordinator):
             warn_msg="[%s] Posible problema de conexión. No se pueden descargar datos diarios de MeteoGalicia",
             restore_msg="[%s] Datos diarios recuperados tras el error previo",
             error_context="datos diarios de estación",
+            data_timestamp_fn=_station_daily_timestamp,
+            data_max_age=_DAILY_DATA_MAX_AGE,
         )
 
 
@@ -266,4 +375,5 @@ class MeteoGaliciaStationLast10MinCoordinator(BaseMeteoGaliciaCoordinator):
             warn_msg="[%s] Posible problema de conexión. No se pueden descargar datos de los últimos 10 minutos de MeteoGalicia",
             restore_msg="[%s] Datos de los últimos 10 minutos recuperados tras el error previo",
             error_context="datos de últimos 10 minutos de estación",
+            data_timestamp_fn=_station_last10_timestamp,
         )

--- a/custom_components/meteogalicia/diagnostics.py
+++ b/custom_components/meteogalicia/diagnostics.py
@@ -30,6 +30,9 @@ def _coordinator_diagnostics(coordinator) -> dict:
             coordinator, "last_api_connected_at", None
         ),
         "last_api_latency_ms": getattr(coordinator, "last_api_latency_ms", None),
+        "data_timestamp": getattr(coordinator, "data_timestamp", None),
+        "data_age_seconds": getattr(coordinator, "data_age_seconds", None),
+        "data_stale": getattr(coordinator, "data_is_stale", None),
         "scan_interval_seconds": (
             interval.total_seconds() if interval is not None else None
         ),

--- a/custom_components/meteogalicia/manifest.json
+++ b/custom_components/meteogalicia/manifest.json
@@ -15,6 +15,6 @@
     "MeteoGalicia-API==0.1.2"
   ],
   "ssdp": [],
-  "version": "2026.08.3",
+  "version": "2026.08.4",
   "zeroconf": []
 }

--- a/custom_components/meteogalicia/sensor.py
+++ b/custom_components/meteogalicia/sensor.py
@@ -68,12 +68,21 @@ class MeteoGaliciaExtraAttrsMixin:
     @property
     def extra_state_attributes(self):
         base_attr = getattr(self, "_attr", {}) or {}
-        return {
+        attributes = {
             **base_attr,
             const.ATTR_CONNECTED_AT: _get_coordinator_connected_at(self.coordinator),
             const.ATTR_API_LATENCY_MS: _get_coordinator_api_latency_ms(self.coordinator),
             const.ATTR_SCAN_INTERVAL_S: _get_coordinator_scan_interval(self.coordinator),
         }
+        if (timestamp := getattr(self.coordinator, "data_timestamp", None)) is not None:
+            attributes[const.ATTR_DATA_TIMESTAMP] = timestamp
+            attributes[const.ATTR_DATA_AGE_S] = getattr(
+                self.coordinator, "data_age_seconds", None
+            )
+            attributes[const.ATTR_DATA_STALE] = getattr(
+                self.coordinator, "data_is_stale", None
+            )
+        return attributes
 
 
 def _get_coordinator_connected_at(coordinator) -> str:

--- a/custom_components/meteogalicia/weather.py
+++ b/custom_components/meteogalicia/weather.py
@@ -226,6 +226,17 @@ class MeteoGaliciaWeather(CoordinatorEntity, WeatherEntity):
             else None
         )
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose the real observation time and whether it is stale."""
+        coordinator = self._observation_coordinator
+        attributes = {
+            "observation_timestamp": getattr(coordinator, "data_timestamp", None),
+            "observation_age_s": getattr(coordinator, "data_age_seconds", None),
+            "observation_stale": getattr(coordinator, "data_is_stale", None),
+        }
+        return {key: value for key, value in attributes.items() if value is not None}
+
     async def async_forecast_daily(self) -> list[dict[str, Any]] | None:
         """Return the daily forecast."""
         forecast = []

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,7 @@
 homeassistant==2026.8.1
 MeteoGalicia-API==0.1.2
-pytest==9.1.1
+pytest==9.0.3
 pytest-asyncio==1.4.0
+pytest-cov==7.1.0
+pytest-homeassistant-custom-component==0.13.355
 ruff==0.16.2

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.projectKey=Danieldiazi_homeassistant-meteogalicia
+sonar.organization=danieldiazi
+sonar.sources=custom_components/meteogalicia
+sonar.tests=tests
+sonar.python.coverage.reportPaths=coverage.xml
+sonar.python.version=3.14
+sonar.sourceEncoding=UTF-8

--- a/tests/test_coordinator_failures.py
+++ b/tests/test_coordinator_failures.py
@@ -20,6 +20,8 @@ def _coordinator_double():
         _restore_msg="Datos recuperados para %s",
         _had_data_error=False,
         id="15009",
+        _update_data_timestamp=lambda _data: None,
+        _check_staleness_transition=lambda: None,
     )
 
 

--- a/tests/test_coordinator_freshness.py
+++ b/tests/test_coordinator_freshness.py
@@ -1,0 +1,97 @@
+"""Tests for actual observation timestamps and stale-data detection."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from custom_components.meteogalicia import coordinator as coordinator_module
+from custom_components.meteogalicia.coordinator import (
+    MeteoGaliciaObservationCoordinator,
+    MeteoGaliciaStationDailyCoordinator,
+    MeteoGaliciaStationLast10MinCoordinator,
+    _parse_api_timestamp,
+)
+
+
+def test_api_timestamp_parser_normalises_naive_utc_values():
+    assert _parse_api_timestamp("2026-08-08T16:17:00").isoformat() == (
+        "2026-08-08T16:17:00+00:00"
+    )
+    assert _parse_api_timestamp("invalid") is None
+    assert _parse_api_timestamp(None) is None
+
+
+@pytest.mark.parametrize(
+    ("coordinator_class", "payload", "expected_timestamp"),
+    [
+        (
+            MeteoGaliciaObservationCoordinator,
+            {"listaObservacionConcellos": [{"dataUTC": "2026-08-08T16:17:00"}]},
+            "2026-08-08T16:17:00+00:00",
+        ),
+        (
+            MeteoGaliciaStationLast10MinCoordinator,
+            {"listUltimos10min": [{"instanteLecturaUTC": "2026-08-08T16:10:00"}]},
+            "2026-08-08T16:10:00+00:00",
+        ),
+        (
+            MeteoGaliciaStationDailyCoordinator,
+            {"listDatosDiarios": [{"data": "2026-08-08T00:00:00"}]},
+            "2026-08-08T00:00:00+00:00",
+        ),
+    ],
+)
+async def test_coordinators_extract_real_observation_timestamp(
+    hass, monkeypatch, coordinator_class, payload, expected_timestamp
+):
+    monkeypatch.setattr(
+        coordinator_module,
+        "_utcnow",
+        lambda: datetime(2026, 8, 8, 16, 20, tzinfo=timezone.utc),
+    )
+    coordinator = coordinator_class(hass, "15009", 1800)
+
+    coordinator._update_data_timestamp(payload)
+
+    assert coordinator.data_timestamp == expected_timestamp
+    assert coordinator.data_age_seconds is not None
+    await coordinator.async_close()
+
+
+async def test_recent_observation_becomes_stale_after_two_scan_intervals(
+    hass, monkeypatch, caplog
+):
+    current_time = datetime(2026, 8, 8, 17, 18, tzinfo=timezone.utc)
+    monkeypatch.setattr(coordinator_module, "_utcnow", lambda: current_time)
+    coordinator = MeteoGaliciaObservationCoordinator(hass, "15009", 1800)
+
+    coordinator._update_data_timestamp(
+        {"listaObservacionConcellos": [{"dataUTC": "2026-08-08T16:17:00"}]}
+    )
+
+    assert coordinator.data_age_seconds == 3660.0
+    assert coordinator.data_is_stale is True
+    assert "están obsoletos" in caplog.text
+
+    current_time = datetime(2026, 8, 8, 17, 20, tzinfo=timezone.utc)
+    coordinator._update_data_timestamp(
+        {"listaObservacionConcellos": [{"dataUTC": "2026-08-08T17:17:00"}]}
+    )
+    assert coordinator.data_is_stale is False
+    assert "vuelve a proporcionar datos recientes" in caplog.text
+    await coordinator.async_close()
+
+
+async def test_daily_observation_uses_a_48_hour_threshold(hass, monkeypatch):
+    monkeypatch.setattr(
+        coordinator_module,
+        "_utcnow",
+        lambda: datetime(2026, 8, 8, 0, 0, 1, tzinfo=timezone.utc),
+    )
+    coordinator = MeteoGaliciaStationDailyCoordinator(hass, "10124", 1800)
+    coordinator._update_data_timestamp(
+        {"listDatosDiarios": [{"data": "2026-08-06T00:00:00"}]}
+    )
+
+    assert coordinator.data_is_stale is True
+    await coordinator.async_close()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -17,6 +17,9 @@ async def test_diagnostics_include_health_interval_errors_and_entities(monkeypat
         last_update_success=False,
         last_api_connected_at="2026-08-08T16:17:00+00:00",
         last_api_latency_ms=243.2,
+        data_timestamp="2026-08-08T16:17:00+00:00",
+        data_age_seconds=180.0,
+        data_is_stale=False,
         last_exception=TimeoutError("API timeout"),
         data={"private_payload": "not exposed"},
     )
@@ -47,5 +50,7 @@ async def test_diagnostics_include_health_interval_errors_and_entities(monkeypat
     assert result["entry"]["type"] == "municipality"
     assert result["coordinators"][0]["scan_interval_seconds"] == 1800
     assert result["coordinators"][0]["last_error"] == "API timeout"
+    assert result["coordinators"][0]["data_timestamp"] == ("2026-08-08T16:17:00+00:00")
+    assert result["coordinators"][0]["data_stale"] is False
     assert result["entities"][0]["entity_id"] == "weather.betanzos"
     assert "private_payload" not in str(result)

--- a/tests/test_integration_setup.py
+++ b/tests/test_integration_setup.py
@@ -1,0 +1,96 @@
+"""Integration-level setup tests running a real Home Assistant instance."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.meteogalicia import const
+from custom_components.meteogalicia import coordinator as coordinator_module
+
+
+@pytest.mark.asyncio
+async def test_municipality_entry_creates_weather_with_observed_freshness(
+    hass, enable_custom_integrations, monkeypatch
+):
+    forecast = {
+        "predConcello": {
+            "nome": "Betanzos",
+            "listaPredDiaConcello": [
+                {
+                    "dataPredicion": "2026-08-08T00:00:00",
+                    "ceoDia": 101,
+                    "tMax": 28,
+                    "tMin": 17,
+                    "pchoiva": {"manha": 5, "tarde": 10, "noite": 20},
+                    "uvMax": 6,
+                }
+            ],
+        }
+    }
+    observation = {
+        "listaObservacionConcellos": [
+            {
+                "nomeConcello": "Betanzos",
+                "dataLocal": "2026-08-08T18:17:00",
+                "dataUTC": "2026-08-08T16:17:00",
+                "temperatura": 28.0,
+                "sensacionTermica": 28.5,
+                "icoEstadoCeo": 101,
+            }
+        ]
+    }
+    monkeypatch.setattr(
+        coordinator_module,
+        "_get_forecast_data_from_api",
+        lambda _resource_id, _session: forecast,
+    )
+    monkeypatch.setattr(
+        coordinator_module,
+        "_get_observation_data_from_api",
+        lambda _resource_id, _session: observation,
+    )
+    monkeypatch.setattr(
+        coordinator_module,
+        "_utcnow",
+        lambda: datetime(2026, 8, 8, 16, 20, tzinfo=timezone.utc),
+    )
+    entry = MockConfigEntry(
+        domain=const.DOMAIN,
+        title="MeteoGalicia Betanzos",
+        unique_id="concello_15009",
+        data={const.CONF_ID_CONCELLO: "15009"},
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    registry = er.async_get(hass)
+    weather_entries = [
+        item
+        for item in er.async_entries_for_config_entry(registry, entry.entry_id)
+        if item.domain == "weather"
+    ]
+    assert len(weather_entries) == 1
+    state = hass.states.get(weather_entries[0].entity_id)
+    assert state is not None
+    assert state.state == "sunny"
+    assert state.attributes["temperature"] == 28.0
+    assert state.attributes["apparent_temperature"] == 28.5
+    assert state.attributes["observation_timestamp"] == ("2026-08-08T16:17:00+00:00")
+    assert state.attributes["observation_stale"] is False
+
+    observed_temperature = next(
+        item
+        for item in er.async_entries_for_config_entry(registry, entry.entry_id)
+        if item.unique_id == "meteogalicia_betanzos_temperature_15009"
+    )
+    sensor_state = hass.states.get(observed_temperature.entity_id)
+    assert sensor_state is not None
+    assert sensor_state.attributes["data_timestamp"] == ("2026-08-08T16:17:00+00:00")
+    assert sensor_state.attributes["data_stale"] is False
+
+    assert await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -69,6 +69,22 @@ def test_apparent_temperature_and_condition_use_observed_values():
     assert entity.condition == "rainy"
 
 
+def test_weather_exposes_real_observation_freshness():
+    entity = _weather_without_init()
+    entity._observation_coordinator = SimpleNamespace(
+        data=None,
+        data_timestamp="2026-08-08T16:17:00+00:00",
+        data_age_seconds=180.0,
+        data_is_stale=False,
+    )
+
+    assert entity.extra_state_attributes == {
+        "observation_timestamp": "2026-08-08T16:17:00+00:00",
+        "observation_age_s": 180.0,
+        "observation_stale": False,
+    }
+
+
 @pytest.mark.parametrize(
     "payload",
     [


### PR DESCRIPTION
## Resumen

- extrae la marca temporal real de observaciones municipales, datos de últimos 10 minutos y datos diarios
- expone antigüedad y estado obsoleto en `weather`, sensores y diagnósticos
- considera obsoletos los datos recientes después de dos `scan_interval` (mínimo 30 min) y los diarios después de 48 h
- registra una advertencia sólo cuando los datos pasan a obsoletos y un mensaje de recuperación cuando vuelven a ser recientes
- añade pruebas con una instancia real de Home Assistant 2026.8.1
- genera cobertura XML, exige un mínimo del 70 % y prepara su publicación en SonarQube Cloud
- prepara la versión `2026.08.4`

## Compatibilidad

No cambia los `unique_id`, los estados principales ni el `scan_interval` configurado. Los nuevos datos se añaden como atributos y diagnósticos.

## Validación local

- Python 3.14.6
- Home Assistant 2026.8.1
- 57 pruebas superadas
- cobertura total: 71,42 %
- `weather.py`: 94 %
- coordinadores: 84 %
- Ruff crítico, sintaxis y JSON correctos