### PR TITLE
Automate dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: Europe/Madrid
+    open-pull-requests-limit: 5
+    groups:
+      test-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: chore
+      include: scope
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:30"
+      timezone: Europe/Madrid
+    open-pull-requests-limit: 3
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,15 +26,7 @@ jobs:
           cache-dependency-path: requirements_test.txt
 
       - name: Install test dependencies
-        run: >-
-          python -m pip install
-          homeassistant==2026.8.1
-          MeteoGalicia-API==0.1.2
-          pytest==9.0.3
-          pytest-asyncio==1.4.0
-          pytest-cov==7.1.0
-          pytest-homeassistant-custom-component==0.13.355
-          ruff==0.16.2
+        run: python -m pip install -r requirements_test.txt
 
       - name: Validate Python syntax
         run: python -m compileall -q custom_components tests


### PR DESCRIPTION
## What changed

- add grouped weekly Dependabot updates for Python and GitHub Actions
- install test dependencies from `requirements_test.txt` instead of duplicating versions inside the workflow
- use a Monday schedule in the Europe/Madrid timezone

## Why

The test requirements were already current, but CI duplicated the same pins inline and the repository had no Dependabot configuration. Future dependency bumps can now be proposed automatically and immediately validated by the existing test workflow.