### PR TITLE
Evitar actualizaciones incompatibles de pytest

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,5 @@
 homeassistant==2026.8.1
 MeteoGalicia-API==0.1.2
-pytest==9.0.3
 pytest-asyncio==1.4.0
 pytest-cov==7.1.0
 pytest-homeassistant-custom-component==0.13.355


### PR DESCRIPTION
## Qué cambia

- Elimina el pin directo `pytest==9.0.3` de `requirements_test.txt`.
- Mantiene intactas las versiones de Home Assistant y del resto de herramientas de prueba.

## Motivo

`pytest-homeassistant-custom-component==0.13.355` depende exactamente de `pytest==9.0.3`. Dependabot intentó actualizar solo pytest a 9.1.1 en el PR #28, lo que produjo `ResolutionImpossible` durante la instalación.

Al dejar que `pytest-homeassistant-custom-component` instale la versión compatible de pytest, se conserva un entorno de pruebas coherente y se evitan futuras actualizaciones aisladas de pytest.

## Impacto

No modifica la integración ni su comportamiento en Home Assistant. Solo afecta a la resolución de dependencias del entorno de pruebas.

## Validación

GitHub Actions verificará la instalación de dependencias, las comprobaciones de sintaxis y Ruff, y la suite de tests con cobertura.